### PR TITLE
docs: add CI and license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # FerrFlow Benchmarks
 
+[![CI](https://github.com/FerrFlow-Org/Benchmarks/actions/workflows/ci.yml/badge.svg)](https://github.com/FerrFlow-Org/Benchmarks/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/FerrFlow-Org/Benchmarks)](LICENSE)
+
 Reusable GitHub Action for running FerrFlow benchmarks and detecting performance regressions.
 
 ## Usage


### PR DESCRIPTION
## Summary
- Add CI status and license badges to README header
- Aligns with badge convention used across all FerrFlow repos

Closes #6