### PR TITLE
fix: set git identity for benchmark steps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,12 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Configure git identity
+      shell: bash
+      run: |
+        git config user.name "FerrFlow"
+        git config user.email "contact@ferrflow.com"
+
     # ------------------------------------------------------------------
     # Micro benchmarks (criterion)
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Configure `user.name` and `user.email` at the start of the composite action
- Uses `FerrFlow` / `contact@ferrflow.com` as identity for any git operations

Closes #13