### PR TITLE
feat: add release workflow with FerrFlow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (no tags, no release)'
+        type: boolean
+        default: false
 
 jobs:
   lint:
@@ -14,3 +20,32 @@ jobs:
       - uses: actions/checkout@v6
       - name: ShellCheck
         run: shellcheck scripts/*.sh
+
+  release:
+    name: Release
+    needs: lint
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.FERRFLOW_TOKEN }}
+      - name: Configure git
+        run: git remote set-url origin https://x-access-token:${{ secrets.FERRFLOW_TOKEN }}@github.com/${{ github.repository }}
+      - uses: FerrFlow-Org/ferrflow@v2
+        with:
+          dry_run: ${{ inputs.dry_run }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
+      - name: Update major version tag
+        if: inputs.dry_run != true
+        run: |
+          TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+          if [ -n "$TAG" ]; then
+            MAJOR="v$(echo "${TAG#v}" | cut -d. -f1)"
+            git tag -f "$MAJOR"
+            git push origin "refs/tags/$MAJOR" --force
+          fi

--- a/ferrflow.json
+++ b/ferrflow.json
@@ -1,4 +1,8 @@
 {
+  "$schema": "https://ferrflow.com/schema/ferrflow.json",
+  "workspace": {
+    "tagTemplate": "v{version}"
+  },
   "package": [
     {
       "name": "benchmarks",


### PR DESCRIPTION
## Summary
- Add release job to CI workflow using `FerrFlow-Org/ferrflow@v2`
- Runs on push to main (after lint passes) and on manual dispatch
- Updates the major version tag (`v0`) after each release so consumers can pin to `@v0`
- Add `$schema` and `tagTemplate` to `ferrflow.json`
- Support `dry_run` input for testing

Closes #15