### PR TITLE
fix: surface missing baseline in PR comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -152,10 +152,20 @@ runs:
       id: compare
       shell: bash
       run: |
-        if bash ${{ github.action_path }}/scripts/compare.sh benchmarks/results/baseline.json benchmarks/results/latest.json; then
+        set +e
+        output=$(bash ${{ github.action_path }}/scripts/compare.sh benchmarks/results/baseline.json benchmarks/results/latest.json 2>&1)
+        exit_code=$?
+        set -e
+        echo "$output"
+        if echo "$output" | grep -q "status=no-baseline"; then
           echo "regression=false" >> "$GITHUB_OUTPUT"
+          echo "baseline=missing" >> "$GITHUB_OUTPUT"
+        elif [[ $exit_code -eq 0 ]]; then
+          echo "regression=false" >> "$GITHUB_OUTPUT"
+          echo "baseline=found" >> "$GITHUB_OUTPUT"
         else
           echo "regression=true" >> "$GITHUB_OUTPUT"
+          echo "baseline=found" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Post full benchmark results as PR comment
@@ -168,8 +178,12 @@ runs:
           const summary = fs.readFileSync('benchmarks/results/summary.md', 'utf8').trim();
           if (!summary) return;
 
+          const baselineMissing = '${{ steps.compare.outputs.baseline }}' === 'missing';
           const marker = '<!-- ferrflow-full-bench -->';
-          const body = `${marker}\n## Full Benchmark Results (hyperfine)\n\n${summary}`;
+          let body = `${marker}\n## Full Benchmark Results (hyperfine)\n\n${summary}`;
+          if (baselineMissing) {
+            body += '\n\n> **Note:** No baseline found — regression comparison was skipped. A baseline will be saved when this is merged to main.';
+          }
 
           const { data: comments } = await github.rest.issues.listComments({
             owner: context.repo.owner,

--- a/scripts/compare.sh
+++ b/scripts/compare.sh
@@ -18,6 +18,7 @@ fi
 
 if [[ ! -f "$BASELINE" ]]; then
   echo "No baseline found at $BASELINE -- skipping regression check (first run?)" >&2
+  echo "status=no-baseline"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- When no hyperfine baseline artifact exists (first run or expired retention), the PR comment now includes a note explaining that regression comparison was skipped
- `compare.sh` outputs a `status=no-baseline` marker that the action captures as a step output
- The PR comment appends a blockquote notice when baseline is missing

Closes #11

## Test plan

- [ ] Trigger a PR benchmark run on a repo with no existing `hyperfine-baseline` artifact — verify the PR comment includes the "No baseline found" notice
- [ ] Trigger a PR benchmark run with an existing baseline — verify the comment shows comparison results without the notice