### PR TITLE
docs: update usage example to reference v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Reusable GitHub Action for running FerrFlow benchmarks and detecting performance
 ## Usage
 
 ```yaml
-- uses: FerrFlow-Org/Benchmarks@v0
+- uses: FerrFlow-Org/Benchmarks@v2
   with:
     type: micro        # micro, full, or all
     ferrflow-token: ${{ secrets.FERRFLOW_TOKEN }}


### PR DESCRIPTION
## Summary

- Update README usage example from `@v0` to `@v2`
- The `ferrflow-token` input was introduced in v2.0.0 as a breaking change, but the README still pointed to `@v0` which expects the old `github-token` input

Closes #23