### PR TITLE
feat(ci): include benchmark results in releases and step summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
+    outputs:
+      tag: ${{ steps.detect-tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,6 +37,9 @@ jobs:
           token: ${{ secrets.FERRFLOW_TOKEN }}
       - name: Configure git
         run: git remote set-url origin https://x-access-token:${{ secrets.FERRFLOW_TOKEN }}@github.com/${{ github.repository }}
+      - name: Record previous tag
+        id: prev-tag
+        run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
       - uses: FerrFlow-Org/ferrflow@v2
         with:
           dry_run: ${{ inputs.dry_run }}
@@ -49,3 +54,80 @@ jobs:
             git tag -f "$MAJOR"
             git push origin "refs/tags/$MAJOR" --force
           fi
+      - name: Detect new tag
+        id: detect-tag
+        run: |
+          NEW_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo '')
+          PREV_TAG="${{ steps.prev-tag.outputs.tag }}"
+          if [[ -n "$NEW_TAG" && "$NEW_TAG" != "$PREV_TAG" ]]; then
+            echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+  benchmark:
+    name: Benchmark
+    needs: lint
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+        with:
+          repository: FerrFlow-Org/ferrflow
+          path: ferrflow-src
+          token: ${{ secrets.FERRFLOW_TOKEN }}
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ferrflow-src
+      - name: Install hyperfine and jq
+        run: |
+          cargo install hyperfine
+          sudo apt-get install -y jq
+      - name: Build ferrflow
+        run: cargo build --release
+        working-directory: ferrflow-src
+      - name: Add ferrflow to PATH
+        run: echo "${{ github.workspace }}/ferrflow-src/target/release" >> "$GITHUB_PATH"
+      - name: Generate fixtures
+        run: cargo run --release --bin generate-fixtures -- /tmp/bench-fixtures
+        working-directory: ferrflow-src
+      - name: Run benchmarks
+        run: |
+          bash scripts/run.sh \
+            --skip-competitors \
+            --fixtures-dir /tmp/bench-fixtures \
+            --results-dir /tmp/bench-results
+      - name: Step summary
+        run: bash scripts/format-release.sh /tmp/bench-results/latest.json >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload results
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-results
+          path: /tmp/bench-results/latest.json
+          retention-days: 90
+
+  update-release:
+    name: Update release with benchmarks
+    needs: [release, benchmark]
+    runs-on: ubuntu-latest
+    if: needs.release.outputs.tag != ''
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          name: benchmark-results
+          path: /tmp/bench-results
+      - name: Install jq
+        run: sudo apt-get install -y jq
+      - name: Append benchmark results to release
+        run: |
+          TAG="${{ needs.release.outputs.tag }}"
+          PERF=$(bash scripts/format-release.sh /tmp/bench-results/latest.json)
+          CURRENT_BODY=$(gh release view "$TAG" --json body -q '.body' 2>/dev/null || echo "")
+          gh release edit "$TAG" --notes "${CURRENT_BODY}
+
+${PERF}"
+        env:
+          GH_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}

--- a/scripts/format-release.sh
+++ b/scripts/format-release.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Format benchmark results from latest.json as a compact markdown table
+# suitable for GitHub Release bodies and Step Summaries.
+#
+# Usage: ./format-release.sh <latest.json> [--with-delta <baseline.json>]
+#
+# Requires: jq
+
+LATEST="${1:-}"
+BASELINE=""
+
+shift || true
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --with-delta) BASELINE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+if [[ -z "$LATEST" || ! -f "$LATEST" ]]; then
+  echo "Usage: $0 <latest.json> [--with-delta <baseline.json>]" >&2
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "Required command not found: jq" >&2
+  exit 1
+fi
+
+VERSION=$(jq -r '.ferrflow_version' "$LATEST")
+BINARY_SIZE=$(jq -r '.ferrflow_binary_size_mb' "$LATEST")
+
+echo "## Performance"
+echo ""
+echo "| Fixture | Command | Median | Memory |"
+echo "|---------|---------|--------|--------|"
+
+jq -r '
+  .benchmarks | to_entries[]
+  | select(.key | startswith("ferrflow|"))
+  | .key
+' "$LATEST" | sort | while IFS= read -r key; do
+  fixture=$(echo "$key" | cut -d'|' -f2)
+  cmd=$(echo "$key" | cut -d'|' -f3)
+
+  median=$(jq -r ".benchmarks[\"$key\"].median_ms" "$LATEST" | awk '{printf "%.1f", $1}')
+  mem=$(jq -r ".benchmarks[\"$key\"].memory_mb" "$LATEST")
+
+  delta=""
+  if [[ -n "$BASELINE" && -f "$BASELINE" ]]; then
+    old=$(jq -r ".benchmarks[\"$key\"].median_ms // empty" "$BASELINE" 2>/dev/null || echo "")
+    if [[ -n "$old" && "$old" != "null" ]]; then
+      pct=$(awk "BEGIN {printf \"%.0f\", (($median - $old) / $old) * 100}")
+      if [[ "$pct" -gt 0 ]]; then
+        delta=" (+${pct}%)"
+      elif [[ "$pct" -lt 0 ]]; then
+        delta=" (${pct}%)"
+      fi
+    fi
+  fi
+
+  mem_display="N/A"
+  if [[ "$mem" != "N/A" ]]; then
+    mem_display="${mem} MB"
+  fi
+
+  echo "| ${fixture} | ${cmd} | ${median}ms${delta} | ${mem_display} |"
+done
+
+echo ""
+echo "*Binary size: ${BINARY_SIZE} MB — ferrflow ${VERSION}*"


### PR DESCRIPTION
## Summary

- Add `benchmark` job to CI that runs ferrflow benchmarks (hyperfine, skip competitors) on push to main
- Add `update-release` job that appends a performance table to the GitHub Release body when a new tag is created
- Write benchmark results to `GITHUB_STEP_SUMMARY` for visibility in Actions runs
- Add `scripts/format-release.sh` to format `latest.json` into a compact markdown table (supports delta vs baseline)

Closes #30