### PR TITLE
feat: expose full benchmark regression thresholds as action inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Reusable GitHub Action for running FerrFlow benchmarks and detecting performance
 |-------|-------------|---------|
 | `type` | Benchmark type: `micro`, `full`, or `all` | `all` |
 | `skip-competitors` | Skip competitor benchmarks in full mode | `false` |
-| `alert-threshold` | Regression alert threshold (e.g. `120%`) | `120%` |
+| `alert-threshold` | Regression alert threshold for micro benchmarks (e.g. `120%`) | `120%` |
+| `full-regression-threshold` | Relative threshold for full benchmark regressions (e.g. `125%`) | `125%` |
+| `binary-size-threshold` | Binary size growth threshold (e.g. `120%`) | `120%` |
 | `comment-on-pr` | Post benchmark results as PR comment | `true` |
 | `ferrflow-token` | GitHub token for PR comments and artifact access | required |
 
@@ -45,7 +47,7 @@ Runs end-to-end benchmarks with [hyperfine](https://github.com/sharkdp/hyperfine
 
 - Generates fixtures using `cargo run --release --bin generate-fixtures`
 - Measures execution time, memory usage, and binary size
-- Compares against stored baseline and detects regressions (25% threshold)
+- Compares against stored baseline and detects regressions (configurable threshold, default 25%)
 
 ## Requirements
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,14 @@ inputs:
     description: 'Post benchmark results as PR comment'
     required: false
     default: 'true'
+  full-regression-threshold:
+    description: 'Relative threshold for full benchmark regressions (e.g. 125%)'
+    required: false
+    default: '125%'
+  binary-size-threshold:
+    description: 'Binary size growth threshold (e.g. 120%)'
+    required: false
+    default: '120%'
   ferrflow-token:
     description: 'GitHub token for PR comments and artifact access'
     required: true
@@ -153,7 +161,9 @@ runs:
       shell: bash
       run: |
         set +e
-        output=$(bash ${{ github.action_path }}/scripts/compare.sh benchmarks/results/baseline.json benchmarks/results/latest.json 2>&1)
+        output=$(FULL_REGRESSION_THRESHOLD="${{ inputs.full-regression-threshold }}" \
+                 BINARY_SIZE_THRESHOLD="${{ inputs.binary-size-threshold }}" \
+                 bash ${{ github.action_path }}/scripts/compare.sh benchmarks/results/baseline.json benchmarks/results/latest.json 2>&1)
         exit_code=$?
         set -e
         echo "$output"

--- a/scripts/compare.sh
+++ b/scripts/compare.sh
@@ -40,8 +40,19 @@ require_cmd jq
 # Configuration
 # ---------------------------------------------------------------------------
 
-RELATIVE_THRESHOLD=0.25  # 25%
-BINARY_SIZE_THRESHOLD=0.20  # 20%
+# Parse percentage inputs (e.g. "125%" -> 0.25, "120%" -> 0.20)
+_parse_pct() {
+  local raw="$1" default="$2"
+  if [[ -z "$raw" ]]; then
+    echo "$default"
+    return
+  fi
+  raw="${raw%\%}"
+  awk "BEGIN {printf \"%.4f\", ($raw / 100) - 1}" 2>/dev/null || echo "$default"
+}
+
+RELATIVE_THRESHOLD=$(_parse_pct "${FULL_REGRESSION_THRESHOLD:-}" "0.25")
+BINARY_SIZE_THRESHOLD=$(_parse_pct "${BINARY_SIZE_THRESHOLD:-}" "0.20")
 
 # Absolute thresholds (ms)
 declare -A ABS_THRESHOLDS=(
@@ -77,7 +88,8 @@ for key in $(jq -r '.benchmarks | keys[]' "$LATEST" | grep '^ferrflow|'); do
   fi
 
   if (( $(awk "BEGIN {print (($new_median - $old_median) / $old_median > $RELATIVE_THRESHOLD) ? 1 : 0}") )); then
-    echo "  FAIL $key: ${old_median}ms -> ${new_median}ms (${sign}${pct}%) -- exceeds ${RELATIVE_THRESHOLD}x threshold"
+    rel_pct=$(awk "BEGIN {printf \"%.0f\", $RELATIVE_THRESHOLD * 100}")
+    echo "  FAIL $key: ${old_median}ms -> ${new_median}ms (${sign}${pct}%) -- exceeds ${rel_pct}% threshold"
     FAILED=true
   else
     echo "  OK   $key: ${old_median}ms -> ${new_median}ms (${sign}${pct}%)"
@@ -110,7 +122,8 @@ old_size=$(jq -r '.ferrflow_binary_size_mb // empty' "$BASELINE" 2>/dev/null || 
 if [[ -n "$old_size" && "$old_size" != "null" && "$old_size" != "N/A" && "$new_size" != "N/A" ]]; then
   pct=$(awk "BEGIN {printf \"%.1f\", (($new_size - $old_size) / $old_size) * 100}")
   if (( $(awk "BEGIN {print (($new_size - $old_size) / $old_size > $BINARY_SIZE_THRESHOLD) ? 1 : 0}") )); then
-    echo "  FAIL binary size: ${old_size}MB -> ${new_size}MB (+${pct}%) -- exceeds 20% threshold"
+    threshold_pct=$(awk "BEGIN {printf \"%.0f\", $BINARY_SIZE_THRESHOLD * 100}")
+    echo "  FAIL binary size: ${old_size}MB -> ${new_size}MB (+${pct}%) -- exceeds ${threshold_pct}% threshold"
     FAILED=true
   else
     echo "  OK   binary size: ${old_size}MB -> ${new_size}MB (${pct}%)"


### PR DESCRIPTION
## Summary

- Add `full-regression-threshold` input (default `125%`) to control the relative threshold for full (hyperfine) benchmark regressions
- Add `binary-size-threshold` input (default `120%`) to control the binary size growth threshold
- Both are passed as env vars to `scripts/compare.sh` which falls back to current hardcoded values if not set
- Absolute thresholds remain hardcoded as they are fixture-specific safeguards

Closes #21