### PR TITLE
chore(ci): use floatingTags config instead of manual major tag script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,15 +45,6 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
         env:
           GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
-      - name: Update major version tag
-        if: inputs.dry_run != true
-        run: |
-          TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
-          if [ -n "$TAG" ]; then
-            MAJOR="v$(echo "${TAG#v}" | cut -d. -f1)"
-            git tag -f "$MAJOR"
-            git push origin "refs/tags/$MAJOR" --force
-          fi
       - name: Detect new tag
         id: detect-tag
         run: |

--- a/ferrflow.json
+++ b/ferrflow.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://ferrflow.com/schema/ferrflow.json",
   "workspace": {
-    "tagTemplate": "v{version}"
+    "tagTemplate": "v{version}",
+    "floatingTags": ["major"]
   },
   "package": [
     {


### PR DESCRIPTION
Replace the manual CI step that force-pushes the `vX` major tag with FerrFlow's native `floatingTags` config option.

- Add `"floatingTags": ["major"]` to `ferrflow.json` workspace config
- Remove the "Update major version tag" step from `ci.yml`

Closes #36