### PR TITLE
fix(ci): add timeouts to benchmark steps to prevent hanging CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           cargo install hyperfine
           sudo apt-get install -y jq
       - name: Build ferrflow
+        timeout-minutes: 30
         run: cargo build --release
         working-directory: ferrflow-src
       - name: Add ferrflow to PATH
@@ -92,6 +93,7 @@ jobs:
         run: cargo run --release --bin generate-fixtures -- /tmp/bench-fixtures
         working-directory: ferrflow-src
       - name: Run benchmarks
+        timeout-minutes: 60
         run: |
           bash scripts/run.sh \
             --skip-competitors \

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,7 @@ runs:
     - name: Run micro benchmarks
       if: inputs.type == 'micro' || inputs.type == 'all'
       shell: bash
+      timeout-minutes: 30
       run: cargo bench --bench ferrflow_benchmarks -- --output-format bencher 2>/dev/null | tee output.txt
 
     - name: Find baseline artifact from main
@@ -143,6 +144,7 @@ runs:
     - name: Run full benchmarks
       if: inputs.type == 'full' || inputs.type == 'all'
       shell: bash
+      timeout-minutes: 60
       run: |
         ARGS="--fixtures-dir /tmp/bench-fixtures --results-dir benchmarks/results"
         if [[ "${{ inputs.skip-competitors }}" == "true" ]]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -214,6 +214,7 @@ for fixture in "${FIXTURES[@]}"; do
     hyperfine \
       --warmup "$WARMUP" \
       --runs "$RUNS" \
+      --time-limit 300 \
       --export-json "$raw_file" \
       --shell=bash \
       "cd $fixture_path && ferrflow $cmd 2>/dev/null" \
@@ -277,6 +278,7 @@ if ! $SKIP_COMPETITORS && command_exists npx; then
       hyperfine \
         --warmup 1 \
         --runs 3 \
+        --time-limit 300 \
         --export-json "$raw_file" \
         --shell=bash \
         "cd $tmp_dir && $tool_cmd 2>/dev/null" \


### PR DESCRIPTION
Prevent benchmark steps from hanging indefinitely if a tool prompts for input or enters an infinite loop.

- Add `timeout-minutes: 30` to micro benchmarks (`cargo bench`) in `action.yml`
- Add `timeout-minutes: 60` to full benchmarks (`scripts/run.sh`) in `action.yml`
- Add `timeout-minutes: 30` to build step and `timeout-minutes: 60` to run step in `ci.yml`
- Add `--time-limit 300` (5 min) to all hyperfine calls in `scripts/run.sh` so individual benchmarks can't hang

Closes #25