### PR TITLE
fix(bench): replace invalid --time-limit with --max-runs for hyperfine

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -214,7 +214,7 @@ for fixture in "${FIXTURES[@]}"; do
     hyperfine \
       --warmup "$WARMUP" \
       --runs "$RUNS" \
-      --time-limit 300 \
+      --max-runs 50 \
       --export-json "$raw_file" \
       --shell=bash \
       "cd $fixture_path && ferrflow $cmd 2>/dev/null" \
@@ -278,7 +278,7 @@ if ! $SKIP_COMPETITORS && command_exists npx; then
       hyperfine \
         --warmup 1 \
         --runs 3 \
-        --time-limit 300 \
+        --max-runs 50 \
         --export-json "$raw_file" \
         --shell=bash \
         "cd $tmp_dir && $tool_cmd 2>/dev/null" \


### PR DESCRIPTION
The `--time-limit` flag does not exist in hyperfine v1.20. This caused the benchmark job to fail immediately with exit code 2 on main after #40 was merged.

Replace `--time-limit 300` with `--max-runs 50` to cap iterations and prevent benchmarks from running indefinitely, while keeping the `timeout-minutes` on the GitHub Actions steps as the primary safeguard against hangs.

Fixes the CI failure introduced by #40.