### PR TITLE
fix(bench): remove --max-runs conflicting with --runs in hyperfine

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -214,7 +214,6 @@ for fixture in "${FIXTURES[@]}"; do
     hyperfine \
       --warmup "$WARMUP" \
       --runs "$RUNS" \
-      --max-runs 50 \
       --export-json "$raw_file" \
       --shell=bash \
       "cd $fixture_path && ferrflow $cmd 2>/dev/null" \
@@ -278,8 +277,7 @@ if ! $SKIP_COMPETITORS && command_exists npx; then
       hyperfine \
         --warmup 1 \
         --runs 3 \
-        --max-runs 50 \
-        --export-json "$raw_file" \
+          --export-json "$raw_file" \
         --shell=bash \
         "cd $tmp_dir && $tool_cmd 2>/dev/null" \
         2>/dev/null


### PR DESCRIPTION
`--runs` (which sets an exact run count) conflicts with `--max-runs` in hyperfine — using both causes exit code 2. This was introduced in #41.

Remove `--max-runs 50` since `--runs` already caps iterations. The `timeout-minutes` on the GitHub Actions steps (added in #40) remain as the safeguard against hanging benchmarks.