### PR TITLE
fix(ci): fix benchmark timeouts breaking CI

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,6 @@ runs:
     - name: Run micro benchmarks
       if: inputs.type == 'micro' || inputs.type == 'all'
       shell: bash
-      timeout-minutes: 30
       run: cargo bench --bench ferrflow_benchmarks -- --output-format bencher 2>/dev/null | tee output.txt
 
     - name: Find baseline artifact from main
@@ -144,7 +143,6 @@ runs:
     - name: Run full benchmarks
       if: inputs.type == 'full' || inputs.type == 'all'
       shell: bash
-      timeout-minutes: 60
       run: |
         ARGS="--fixtures-dir /tmp/bench-fixtures --results-dir benchmarks/results"
         if [[ "${{ inputs.skip-competitors }}" == "true" ]]; then


### PR DESCRIPTION
Fixes the CI failures introduced by #40 and #41.

- Remove `--max-runs 50` from `run.sh` — conflicts with `--runs` in hyperfine (exit code 2)
- Remove `timeout-minutes` from `action.yml` — not supported in composite actions

The `timeout-minutes` in `ci.yml` (workflow level) remains as the safeguard against hanging benchmarks.