### PR TITLE
fix: create empty micro baseline when artifact is missing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,16 @@ runs:
         github-token: ${{ inputs.ferrflow-token }}
       continue-on-error: true
 
+    - name: Create empty micro baseline if missing
+      if: (inputs.type == 'micro' || inputs.type == 'all') && github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        if [[ ! -f baseline/benchmark-data.json ]]; then
+          mkdir -p baseline
+          echo '[]' > baseline/benchmark-data.json
+          echo "Created empty micro baseline (no previous data found)"
+        fi
+
     - name: Compare and comment (PR)
       if: (inputs.type == 'micro' || inputs.type == 'all') && github.event_name == 'pull_request'
       uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
## Summary
- When the `criterion-baseline` artifact doesn't exist (first run or expired), `benchmark-action/github-action-benchmark` crashes because `baseline/benchmark-data.json` is missing
- Added a fallback step that creates an empty `[]` JSON file when the download fails, so the benchmark action can proceed without a baseline

Closes FerrFlow-Org/Benchmarks#0