### PR TITLE
chore(ci): remove unnecessary configure git step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.FERRFLOW_TOKEN }}
-      - name: Configure git
-        run: git remote set-url origin https://x-access-token:${{ secrets.FERRFLOW_TOKEN }}@github.com/${{ github.repository }}
       - name: Record previous tag
         id: prev-tag
         run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Remove the configure git step that sets remote URL with embedded token. The actions/checkout token parameter already configures the credential helper, and FerrFlow reads FERRFLOW_TOKEN env var for push authentication.