### PR TITLE
refactor: use Fixtures action for benchmark fixture generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,11 @@ jobs:
         working-directory: ferrflow-src
       - name: Add ferrflow to PATH
         run: echo "${{ github.workspace }}/ferrflow-src/target/release" >> "$GITHUB_PATH"
-      - name: Generate fixtures
-        run: cargo run --release --bin generate-fixtures -- /tmp/bench-fixtures
-        working-directory: ferrflow-src
+      - name: Generate benchmark fixtures
+        uses: FerrFlow-Org/Fixtures@v0
+        with:
+          definitions: ferrflow-src/benchmarks/fixtures/definitions
+          generated-dir: /tmp/bench-fixtures
       - name: Run benchmarks
         timeout-minutes: 60
         run: |

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ inputs:
     description: 'Binary size growth threshold (e.g. 120%)'
     required: false
     default: '120%'
+  definitions:
+    description: 'Path to TOML definitions for benchmark fixture generation'
+    required: true
   ferrflow-token:
     description: 'GitHub token for PR comments and artifact access'
     required: true
@@ -145,10 +148,12 @@ runs:
       shell: bash
       run: echo "$PWD/target/release" >> $GITHUB_PATH
 
-    - name: Generate fixtures
+    - name: Generate benchmark fixtures
       if: inputs.type == 'full' || inputs.type == 'all'
-      shell: bash
-      run: cargo run --release --bin generate-fixtures -- /tmp/bench-fixtures
+      uses: FerrFlow-Org/Fixtures@v0
+      with:
+        definitions: ${{ inputs.definitions }}
+        generated-dir: /tmp/bench-fixtures
 
     - name: Run full benchmarks
       if: inputs.type == 'full' || inputs.type == 'all'


### PR DESCRIPTION
## Summary

- Add `definitions` input to the Benchmarks action
- Replace `cargo run --bin generate-fixtures` with `FerrFlow-Org/Fixtures@v0`
- Benchmark fixture definitions now live in the consumer repo (FerrFlow)
- Update CI job to use Fixtures action as well

The `generate-fixtures` binary in FerrFlow is being removed in a separate PR.