### PR TITLE
fix(ci): add FERRFLOW_TOKEN env var to release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
         env:
           GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
+          FERRFLOW_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
       - name: Detect new tag
         id: detect-tag
         run: |


### PR DESCRIPTION
## Summary
- Add `FERRFLOW_TOKEN` env var to the release step alongside `GITHUB_TOKEN`
- FerrFlow CLI uses `FERRFLOW_TOKEN` for git push authentication

Closes #54