### PR TITLE
fix: create results directory before running benchmarks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -159,6 +159,7 @@ runs:
       if: inputs.type == 'full' || inputs.type == 'all'
       shell: bash
       run: |
+        mkdir -p benchmarks/results
         ARGS="--fixtures-dir /tmp/bench-fixtures --results-dir benchmarks/results"
         if [[ "${{ inputs.skip-competitors }}" == "true" ]]; then
           ARGS="$ARGS --skip-competitors"


### PR DESCRIPTION
## Summary
- Add `mkdir -p benchmarks/results` before running full benchmarks
- Fixes failure when the consumer repo doesn't have a `benchmarks/results/` directory

Closes #56