### PR TITLE
fix: suppress shellcheck SC2015 warning

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -221,7 +221,7 @@ for fixture in "${FIXTURES[@]}"; do
       2>/dev/null
 
     # Memory (single run)
-    # shellcheck disable=SC2086
+    # shellcheck disable=SC2086,SC2015
     mem=$(cd "$fixture_path" && measure_memory ferrflow $cmd || true)
     # Stash memory in a sidecar file
     echo "$mem" > "$RAW_DIR/${fixture}-ferrflow-${cmd_name}.mem"


### PR DESCRIPTION
Add SC2015 to the existing shellcheck disable comment. The `A && B || C` pattern is intentional here.