### PR TITLE
feat: refactor benchmarks to use tools.json and tool_configs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -161,6 +161,7 @@ runs:
       run: |
         mkdir -p benchmarks/results
         ARGS="--fixtures-dir /tmp/bench-fixtures --results-dir benchmarks/results"
+        ARGS="$ARGS --definitions-dir ${{ inputs.definitions }}"
         if [[ "${{ inputs.skip-competitors }}" == "true" ]]; then
           ARGS="$ARGS --skip-competitors"
         fi

--- a/scripts/compare.sh
+++ b/scripts/compare.sh
@@ -56,9 +56,9 @@ BINARY_SIZE_THRESHOLD=$(_parse_pct "${BINARY_SIZE_THRESHOLD:-}" "0.20")
 
 # Absolute thresholds (ms)
 declare -A ABS_THRESHOLDS=(
-  ["ferrflow|mono-large|check"]=2000
-  ["ferrflow|mono-large|version"]=500
-  ["ferrflow|mono-large|tag"]=500
+  ["mono-large-ferrflow-binary-check"]=2000
+  ["mono-large-ferrflow-binary-version"]=500
+  ["mono-large-ferrflow-binary-tag"]=500
 )
 
 # ---------------------------------------------------------------------------
@@ -72,7 +72,7 @@ echo "=========================="
 echo ""
 
 # Relative checks (ferrflow benchmarks only)
-for key in $(jq -r '.benchmarks | keys[]' "$LATEST" | grep '^ferrflow|'); do
+for key in $(jq -r '.benchmarks | keys[]' "$LATEST" | grep '\-ferrflow-'); do
   new_median=$(jq -r ".benchmarks[\"$key\"].median_ms" "$LATEST")
   old_median=$(jq -r ".benchmarks[\"$key\"].median_ms // empty" "$BASELINE" 2>/dev/null || echo "")
 

--- a/scripts/format-release.sh
+++ b/scripts/format-release.sh
@@ -34,17 +34,13 @@ BINARY_SIZE=$(jq -r '.ferrflow_binary_size_mb' "$LATEST")
 
 echo "## Performance"
 echo ""
-echo "| Fixture | Command | Median | Memory |"
-echo "|---------|---------|--------|--------|"
+echo "| Fixture | Tool | Method | Command | Median | Memory |"
+echo "|---------|------|--------|---------|--------|--------|"
 
-jq -r '
-  .benchmarks | to_entries[]
-  | select(.key | startswith("ferrflow|"))
-  | .key
-' "$LATEST" | sort | while IFS= read -r key; do
-  fixture=$(echo "$key" | cut -d'|' -f2)
-  cmd=$(echo "$key" | cut -d'|' -f3)
-
+jq -r '.benchmarks | keys[]' "$LATEST" | sort | while IFS= read -r key; do
+  # Parse key: fixture-tool-method-cmd
+  # Split on '-' but tool names can contain '-' (semantic-release)
+  # Use jq to get median/stddev
   median=$(jq -r ".benchmarks[\"$key\"].median_ms" "$LATEST" | awk '{printf "%.1f", $1}')
   mem=$(jq -r ".benchmarks[\"$key\"].memory_mb" "$LATEST")
 
@@ -66,68 +62,8 @@ jq -r '
     mem_display="${mem} MB"
   fi
 
-  echo "| ${fixture} | ${cmd} | ${median}ms${delta} | ${mem_display} |"
+  echo "| ${key} | ${median}ms${delta} | ${mem_display} |"
 done
-
-# ---------------------------------------------------------------------------
-# Competitor comparison (only when competitor data is present)
-# ---------------------------------------------------------------------------
-
-COMPETITOR_KEYS=$(jq -r '
-  .benchmarks | keys[] | select(startswith("ferrflow|") | not)
-' "$LATEST" 2>/dev/null || true)
-
-if [[ -n "$COMPETITOR_KEYS" ]]; then
-  # Collect fixtures that have both ferrflow and competitor data
-  COMP_FIXTURES=$(echo "$COMPETITOR_KEYS" | cut -d'|' -f2 | sort -u)
-
-  echo ""
-  echo "### vs. competitors"
-  echo ""
-  echo "| Fixture | Tool | Median | Memory |"
-  echo "|---------|------|--------|--------|"
-
-  echo "$COMP_FIXTURES" | while IFS= read -r fixture; do
-    # FerrFlow check for this fixture
-    ff_key="ferrflow|${fixture}|check"
-    ff_median=$(jq -r ".benchmarks[\"$ff_key\"].median_ms // empty" "$LATEST" 2>/dev/null || echo "")
-    ff_mem=$(jq -r ".benchmarks[\"$ff_key\"].memory_mb // empty" "$LATEST" 2>/dev/null || echo "")
-
-    if [[ -n "$ff_median" && "$ff_median" != "null" ]]; then
-      ff_median_fmt=$(echo "$ff_median" | awk '{printf "%.1f", $1}')
-      ff_mem_display="N/A"
-      if [[ -n "$ff_mem" && "$ff_mem" != "N/A" && "$ff_mem" != "null" ]]; then
-        ff_mem_display="${ff_mem} MB"
-      fi
-      echo "| ${fixture} | **ferrflow** | **${ff_median_fmt}ms** | **${ff_mem_display}** |"
-    fi
-
-    # Competitor entries for this fixture
-    echo "$COMPETITOR_KEYS" | grep "|${fixture}|" | sort | while IFS= read -r ckey; do
-      tool=$(echo "$ckey" | cut -d'|' -f1)
-      c_median=$(jq -r ".benchmarks[\"$ckey\"].median_ms // empty" "$LATEST" 2>/dev/null || echo "")
-      c_mem=$(jq -r ".benchmarks[\"$ckey\"].memory_mb // empty" "$LATEST" 2>/dev/null || echo "")
-
-      if [[ -z "$c_median" || "$c_median" == "null" || "$c_median" == "0" ]]; then
-        continue
-      fi
-
-      c_median_fmt=$(echo "$c_median" | awk '{printf "%.1f", $1}')
-      c_mem_display="N/A"
-      if [[ -n "$c_mem" && "$c_mem" != "N/A" && "$c_mem" != "null" ]]; then
-        c_mem_display="${c_mem} MB"
-      fi
-
-      # Compute slowdown factor vs ferrflow
-      slowdown=""
-      if [[ -n "$ff_median" && "$ff_median" != "null" ]]; then
-        slowdown=$(awk "BEGIN {x = $c_median / $ff_median; if (x >= 1.5) printf \" (%.0fx)\", x}")
-      fi
-
-      echo "| ${fixture} | ${tool} | ${c_median_fmt}ms${slowdown} | ${c_mem_display} |"
-    done
-  done
-fi
 
 echo ""
 echo "*Binary size: ${BINARY_SIZE} MB — ferrflow ${VERSION}*"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,13 +3,16 @@ set -euo pipefail
 
 # FerrFlow Benchmark Runner (hyperfine)
 #
-# Usage: ./run.sh [--json] [--skip-competitors] [--fixtures-dir <path>] [--results-dir <path>]
+# Usage: ./run.sh [--json] [--skip-competitors] [--fixtures-dir <path>]
+#                 [--results-dir <path>] [--definitions-dir <path>]
 #
-# Requires: ferrflow, hyperfine, jq, /usr/bin/time (GNU), node/npx (for competitors)
+# Requires: ferrflow, hyperfine, jq
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TOOLS_JSON="$SCRIPT_DIR/../tools.json"
 FIXTURES_DIR=""
 RESULTS_DIR=""
+DEFINITIONS_DIR=""
 RAW_DIR=""
 OUTPUT_FORMAT="markdown"
 SKIP_COMPETITORS=false
@@ -22,6 +25,7 @@ while [[ $# -gt 0 ]]; do
     --skip-competitors) SKIP_COMPETITORS=true; shift ;;
     --fixtures-dir) FIXTURES_DIR="$2"; shift 2 ;;
     --results-dir) RESULTS_DIR="$2"; shift 2 ;;
+    --definitions-dir) DEFINITIONS_DIR="$2"; shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -33,6 +37,7 @@ fi
 if [[ -z "$RESULTS_DIR" ]]; then
   RESULTS_DIR="$SCRIPT_DIR/../results"
 fi
+
 RAW_DIR="$RESULTS_DIR/raw"
 
 # ---------------------------------------------------------------------------
@@ -48,76 +53,26 @@ require_cmd() {
   fi
 }
 
-# Setup minimal config files so competitor tools can run meaningfully
-# on the generated fixtures. Without these, most tools exit immediately
-# with a config error — benchmarking that is useless.
-setup_competitor_config() {
+# Write tool_configs files from a definition into a directory
+write_tool_configs() {
   local tool="$1"
-  local dir="$2"
+  local target_dir="$2"
+  local def_file="$3"
 
-  case "$tool" in
-    semantic-release)
-      # Use only commit-analyzer and release-notes-generator (no GitHub plugin).
-      # Point remote to the local repo via file:// so git fetch succeeds.
-      cat > "$dir/.releaserc.json" <<'CONF'
-{
-  "branches": ["main"],
-  "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator"
-  ]
-}
-CONF
-      git -C "$dir" remote remove origin &>/dev/null || true
-      git -C "$dir" remote add origin "file://$dir"
-      ;;
-    changesets)
-      mkdir -p "$dir/.changeset"
-      cat > "$dir/.changeset/config.json" <<'CONF'
-{
-  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": false,
-  "commit": false,
-  "access": "restricted",
-  "baseBranch": "main"
-}
-CONF
-      # Create a dummy changeset so `status` has something to evaluate
-      local pkg_name="pkg-001"
-      if [[ -f "$dir/.ferrflow" ]] && command_exists jq; then
-        pkg_name=$(jq -r '.package[0].name // "pkg-001"' "$dir/.ferrflow")
-      fi
-      cat > "$dir/.changeset/benchmark-dummy.md" <<CONF
----
-"$pkg_name": minor
----
-
-benchmark changeset
-CONF
-      git -C "$dir" add .changeset/benchmark-dummy.md &>/dev/null
-      git -C "$dir" commit -m "chore: add benchmark changeset" --allow-empty &>/dev/null || true
-      ;;
-  esac
-}
-
-# Run a command once and check it exits 0. Returns 1 if the tool
-# cannot run meaningfully on this fixture.
-validate_competitor() {
-  local tool="$1"
-  local cmd="$2"
-  local dir="$3"
-
-  local stderr_file
-  stderr_file=$(mktemp)
-  if (cd "$dir" && eval "$cmd" >/dev/null 2>"$stderr_file"); then
-    rm -f "$stderr_file"
-    return 0
+  if [[ -z "$def_file" || ! -f "$def_file" ]]; then
+    return
   fi
-  local reason
-  reason=$(tail -1 "$stderr_file" 2>/dev/null || echo "unknown error")
-  rm -f "$stderr_file"
-  echo "    SKIP $tool: validation failed — $reason" >&2
-  return 1
+
+  # Extract tool_configs.<tool> and write each file
+  local files
+  files=$(jq -r --arg t "$tool" '.tool_configs[$t] // {} | to_entries[] | "\(.key)\t\(.value)"' "$def_file" 2>/dev/null) || return 0
+
+  while IFS=$'\t' read -r path content; do
+    [[ -z "$path" ]] && continue
+    local full_path="$target_dir/$path"
+    mkdir -p "$(dirname "$full_path")"
+    echo "$content" > "$full_path"
+  done <<< "$files"
 }
 
 # Measure peak RSS in MB (Linux only)
@@ -165,144 +120,156 @@ extract_stddev() {
 }
 
 # ---------------------------------------------------------------------------
-# Generate fixtures if missing
-# ---------------------------------------------------------------------------
-
-if [[ ! -d "$FIXTURES_DIR/single" || ! -d "$FIXTURES_DIR/mono-medium" ]]; then
-  echo "Generating fixtures..." >&2
-  cargo run --release --bin generate-fixtures -- "$FIXTURES_DIR"
-fi
-
-# ---------------------------------------------------------------------------
 # Setup
 # ---------------------------------------------------------------------------
 
-require_cmd ferrflow
 require_cmd hyperfine
 require_cmd jq
 
 mkdir -p "$RAW_DIR"
 
-FIXTURES=("single" "mono-small" "mono-medium" "mono-large")
-FIXTURE_LABELS=("single" "mono-small (10 pkg)" "mono-medium (50 pkg)" "mono-large (200 pkg)")
-FERRFLOW_CMDS=("check" "release --dry-run" "version" "tag")
-FERRFLOW_CMD_NAMES=("check" "release-dry" "version" "tag")
-COMPETITOR_FIXTURES=("single" "mono-small" "mono-medium" "mono-large")
+# Read tool definitions
+TOOLS=$(jq -r 'keys[]' "$TOOLS_JSON")
 
-FERRFLOW_BIN_SIZE=$(get_binary_size ferrflow)
+# Discover fixtures from generated dir
+FIXTURES=()
+for d in "$FIXTURES_DIR"/*/; do
+  [[ -d "$d" ]] && FIXTURES+=("$(basename "$d")")
+done
+
+if [[ ${#FIXTURES[@]} -eq 0 ]]; then
+  echo "No fixtures found in $FIXTURES_DIR" >&2
+  exit 1
+fi
 
 echo "Running benchmarks..." >&2
+echo "  Fixtures: ${FIXTURES[*]}" >&2
+echo "  Tools: $TOOLS" >&2
 
 # ---------------------------------------------------------------------------
-# FerrFlow benchmarks
+# Run benchmarks per tool
 # ---------------------------------------------------------------------------
 
-for fixture in "${FIXTURES[@]}"; do
-  fixture_path="$FIXTURES_DIR/$fixture"
-  if [[ ! -d "$fixture_path" ]]; then
-    echo "  Fixture not found: $fixture, skipping" >&2
+for tool in $TOOLS; do
+  # Skip competitors if requested
+  if $SKIP_COMPETITORS && [[ "$tool" != "ferrflow" ]]; then
+    echo "  Skipping $tool (--skip-competitors)" >&2
     continue
   fi
 
-  echo "  Fixture: $fixture" >&2
+  # Read tool config from tools.json
+  install_methods=$(jq -r --arg t "$tool" '.[$t].install_methods | keys[]' "$TOOLS_JSON")
+  # commands are read per-fixture below via jq
 
-  for i in "${!FERRFLOW_CMDS[@]}"; do
-    cmd="${FERRFLOW_CMDS[$i]}"
-    cmd_name="${FERRFLOW_CMD_NAMES[$i]}"
-    raw_file="$RAW_DIR/${fixture}-ferrflow-${cmd_name}.json"
+  for method in $install_methods; do
+    tool_cmd=$(jq -r --arg t "$tool" --arg m "$method" '.[$t].install_methods[$m].command' "$TOOLS_JSON")
+    setup_cmd=$(jq -r --arg t "$tool" --arg m "$method" '.[$t].install_methods[$m].setup // empty' "$TOOLS_JSON")
 
-    echo "    ferrflow $cmd..." >&2
-    hyperfine \
-      --warmup "$WARMUP" \
-      --runs "$RUNS" \
-      --export-json "$raw_file" \
-      --shell=bash \
-      "cd $fixture_path && ferrflow $cmd 2>/dev/null || true" \
-      2>/dev/null
+    # Check if the tool is available
+    local_bin=$(echo "$tool_cmd" | awk '{print $1}')
+    if [[ "$method" == "binary" ]] && ! command_exists "$local_bin"; then
+      echo "  SKIP $tool/$method: $local_bin not found" >&2
+      continue
+    fi
+    if [[ "$method" == "npm" ]] && ! command_exists npx; then
+      echo "  SKIP $tool/$method: npx not available" >&2
+      continue
+    fi
+    if [[ "$method" == "docker" ]] && ! command_exists docker; then
+      echo "  SKIP $tool/$method: docker not available" >&2
+      continue
+    fi
 
-    # Memory (single run)
-    # shellcheck disable=SC2086,SC2015
-    mem=$(cd "$fixture_path" && measure_memory ferrflow $cmd || true)
-    # Stash memory in a sidecar file
-    echo "$mem" > "$RAW_DIR/${fixture}-ferrflow-${cmd_name}.mem"
-  done
-done
+    # Run setup if needed
+    if [[ -n "$setup_cmd" ]]; then
+      echo "  Setting up $tool/$method..." >&2
+      eval "$setup_cmd" &>/dev/null 2>&1 || {
+        echo "  SKIP $tool/$method: setup failed" >&2
+        continue
+      }
+    fi
 
-# ---------------------------------------------------------------------------
-# Competitor benchmarks
-# ---------------------------------------------------------------------------
+    # Measure install size
+    if [[ "$method" == "npm" ]]; then
+      pkg_name=$(echo "$setup_cmd" | grep -oP 'install -g \K\S+' || echo "$tool")
+      echo "  Measuring $tool npm install size..." >&2
+      npm_size=$(get_npm_size "$pkg_name" 2>/dev/null || echo "N/A")
+      echo "$npm_size" > "$RAW_DIR/${tool}-npm-size.txt"
+    fi
+    if [[ "$method" == "binary" && "$tool" == "ferrflow" ]]; then
+      bin_size=$(get_binary_size ferrflow)
+      echo "$bin_size" > "$RAW_DIR/ferrflow-binary-size.txt"
+    fi
 
-if ! $SKIP_COMPETITORS && command_exists npx; then
-  FERRFLOW_NPM_SIZE=$(get_npm_size ferrflow 2>/dev/null || echo "N/A")
-  echo "$FERRFLOW_NPM_SIZE" > "$RAW_DIR/ferrflow-npm-size.txt"
-
-  # release-please is excluded: every command requires GitHub API access,
-  # there is no local-only mode. Only install size is measured (below).
-  declare -A COMPETITOR_CMDS=(
-    ["semantic-release"]="npx --yes semantic-release --dry-run --no-ci"
-    ["changesets"]="npx --yes @changesets/cli status"
-  )
-  declare -A COMPETITOR_PKGS=(
-    ["semantic-release"]="semantic-release"
-    ["changesets"]="@changesets/cli"
-    ["release-please"]="release-please"
-  )
-
-  for tool in "semantic-release" "changesets"; do
-    tool_cmd="${COMPETITOR_CMDS[$tool]}"
-    pkg="${COMPETITOR_PKGS[$tool]}"
-
-    # Install size (once)
-    echo "  Measuring $tool install size..." >&2
-    npm_size=$(get_npm_size "$pkg" 2>/dev/null || echo "N/A")
-    echo "$npm_size" > "$RAW_DIR/${tool}-npm-size.txt"
-
-    for fixture in "${COMPETITOR_FIXTURES[@]}"; do
+    for fixture in "${FIXTURES[@]}"; do
       fixture_path="$FIXTURES_DIR/$fixture"
-      if [[ ! -d "$fixture_path" ]]; then continue; fi
+      if [[ ! -d "$fixture_path" ]]; then
+        continue
+      fi
 
-      raw_file="$RAW_DIR/${fixture}-${tool}-check.json"
+      # Find the definition file for this fixture
+      def_file=""
+      if [[ -n "$DEFINITIONS_DIR" && -f "$DEFINITIONS_DIR/${fixture}.json" ]]; then
+        def_file="$DEFINITIONS_DIR/${fixture}.json"
+      fi
 
-      echo "    $tool on $fixture..." >&2
-      # Run in a temp copy to avoid polluting fixtures
+      # Work on a copy so tool configs don't pollute the original
       tmp_dir=$(mktemp -d)
       cp -a "$fixture_path/." "$tmp_dir/"
 
-      setup_competitor_config "$tool" "$tmp_dir"
+      # Write tool-specific config files
+      write_tool_configs "$tool" "$tmp_dir" "$def_file"
 
-      if ! validate_competitor "$tool" "$tool_cmd" "$tmp_dir"; then
-        echo "N/A" > "$RAW_DIR/${fixture}-${tool}-check.mem"
-        rm -rf "$tmp_dir"
-        continue
-      fi
+      # Build commands to benchmark
+      readarray -t cmds < <(jq -r --arg t "$tool" '.[$t].commands[]' "$TOOLS_JSON")
 
-      hyperfine \
-        --warmup 1 \
-        --runs 3 \
-        --export-json "$raw_file" \
-        --shell=bash \
-        "cd $tmp_dir && $tool_cmd 2>/dev/null" \
-        2>/dev/null
+      for cmd in "${cmds[@]}"; do
+        # For tools with empty command (semantic-release, changesets), the full command is in tool_cmd
+        if [[ -z "$cmd" ]]; then
+          full_cmd="$tool_cmd"
+          cmd_name="check"
+        else
+          full_cmd="$tool_cmd $cmd"
+          cmd_name=$(echo "$cmd" | tr ' ' '-' | tr -d '-')
+          # Normalize: "release --dry-run" -> "release-dry"
+          cmd_name=$(echo "$cmd" | sed 's/ --/-/g; s/ /-/g; s/--/-/g')
+        fi
 
-      if [[ ! -s "$raw_file" ]]; then
-        echo "    WARN: $tool on $fixture produced no benchmark results" >&2
-        rm -rf "$tmp_dir"
-        continue
-      fi
+        label="${tool}/${method}"
+        raw_file="$RAW_DIR/${fixture}-${tool}-${method}-${cmd_name}.json"
 
-      # shellcheck disable=SC2086
-      mem=$(cd "$tmp_dir" && measure_memory $tool_cmd 2>/dev/null || echo "N/A")
-      echo "$mem" > "$RAW_DIR/${fixture}-${tool}-check.mem"
+        echo "  $label: $cmd on $fixture..." >&2
+
+        # Validate the command works before benchmarking
+        if ! (cd "$tmp_dir" && eval "$full_cmd" >/dev/null 2>&1); then
+          echo "    SKIP: command failed" >&2
+          continue
+        fi
+
+        hyperfine \
+          --warmup "$WARMUP" \
+          --runs "$RUNS" \
+          --export-json "$raw_file" \
+          --shell=bash \
+          "cd $tmp_dir && $full_cmd 2>/dev/null || true" \
+          2>/dev/null
+
+        # Memory (single run)
+        # shellcheck disable=SC2086
+        mem=$(cd "$tmp_dir" && measure_memory $full_cmd 2>/dev/null || echo "N/A")
+        echo "$mem" > "$RAW_DIR/${fixture}-${tool}-${method}-${cmd_name}.mem"
+      done
 
       rm -rf "$tmp_dir"
     done
   done
-  # Measure release-please install size (no runtime benchmark — requires GitHub API)
+done
+
+# Measure release-please install size (no runtime benchmark — requires GitHub API)
+if ! $SKIP_COMPETITORS && command_exists npx; then
   echo "  Measuring release-please install size..." >&2
   rp_size=$(get_npm_size "release-please" 2>/dev/null || echo "N/A")
   echo "$rp_size" > "$RAW_DIR/release-please-npm-size.txt"
-else
-  echo "  Skipping competitors (npx not available or --skip-competitors)" >&2
 fi
 
 # ---------------------------------------------------------------------------
@@ -311,6 +278,7 @@ fi
 
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 FERRFLOW_VERSION=$(ferrflow --version 2>/dev/null | head -1 || echo "unknown")
+FERRFLOW_BIN_SIZE=$(cat "$RAW_DIR/ferrflow-binary-size.txt" 2>/dev/null || echo "N/A")
 FERRFLOW_NPM_SIZE=$(cat "$RAW_DIR/ferrflow-npm-size.txt" 2>/dev/null || echo "N/A")
 
 {
@@ -322,41 +290,18 @@ FERRFLOW_NPM_SIZE=$(cat "$RAW_DIR/ferrflow-npm-size.txt" 2>/dev/null || echo "N/
   echo "  \"benchmarks\": {"
 
   first_bench=true
-  for fixture in "${FIXTURES[@]}"; do
-    for i in "${!FERRFLOW_CMD_NAMES[@]}"; do
-      cmd_name="${FERRFLOW_CMD_NAMES[$i]}"
-      raw_file="$RAW_DIR/${fixture}-ferrflow-${cmd_name}.json"
-      mem_file="$RAW_DIR/${fixture}-ferrflow-${cmd_name}.mem"
-      if [[ ! -f "$raw_file" ]]; then continue; fi
+  for raw_file in "$RAW_DIR"/*.json; do
+    [[ -f "$raw_file" ]] || continue
+    basename=$(basename "$raw_file" .json)
 
-      median=$(extract_median "$raw_file")
-      stddev=$(extract_stddev "$raw_file")
-      mem=$(cat "$mem_file" 2>/dev/null || echo "N/A")
+    median=$(extract_median "$raw_file" 2>/dev/null || echo "0")
+    stddev=$(extract_stddev "$raw_file" 2>/dev/null || echo "0")
+    mem=$(cat "$RAW_DIR/${basename}.mem" 2>/dev/null || echo "N/A")
 
-      if ! $first_bench; then echo ","; fi
-      first_bench=false
-      printf '    "ferrflow|%s|%s": {"median_ms": %s, "stddev_ms": %s, "memory_mb": "%s"}' \
-        "$fixture" "$cmd_name" "$median" "$stddev" "$mem"
-    done
-  done
-
-  # Competitors (only tools with runtime benchmarks)
-  for tool in "semantic-release" "changesets"; do
-    for fixture in "${COMPETITOR_FIXTURES[@]}"; do
-      raw_file="$RAW_DIR/${fixture}-${tool}-check.json"
-      mem_file="$RAW_DIR/${fixture}-${tool}-check.mem"
-      if [[ ! -f "$raw_file" ]]; then continue; fi
-
-      median=$(extract_median "$raw_file" 2>/dev/null || echo "0")
-      stddev=$(extract_stddev "$raw_file" 2>/dev/null || echo "0")
-      mem=$(cat "$mem_file" 2>/dev/null || echo "N/A")
-      npm_size=$(cat "$RAW_DIR/${tool}-npm-size.txt" 2>/dev/null || echo "N/A")
-
-      if ! $first_bench; then echo ","; fi
-      first_bench=false
-      printf '    "%s|%s|check": {"median_ms": %s, "stddev_ms": %s, "memory_mb": "%s", "npm_size_mb": "%s"}' \
-        "$tool" "$fixture" "$median" "$stddev" "$mem" "$npm_size"
-    done
+    if ! $first_bench; then echo ","; fi
+    first_bench=false
+    printf '    "%s": {"median_ms": %s, "stddev_ms": %s, "memory_mb": "%s"}' \
+      "$basename" "$median" "$stddev" "$mem"
   done
 
   echo ""
@@ -374,48 +319,27 @@ echo "Results saved to $RESULTS_DIR/latest.json" >&2
 if [[ "$OUTPUT_FORMAT" == "json" ]]; then
   cat "$RESULTS_DIR/latest.json"
 else
-  for i in "${!FIXTURES[@]}"; do
-    fixture="${FIXTURES[$i]}"
-    label="${FIXTURE_LABELS[$i]}"
-
+  for fixture in "${FIXTURES[@]}"; do
     echo ""
-    echo "### ${label}"
+    echo "### ${fixture}"
     echo ""
-    echo "| Tool | Command | Median | Stddev | Binary/Install | Memory (RSS) |"
-    echo "|------|---------|--------|--------|----------------|--------------|"
+    echo "| Tool | Method | Command | Median | Stddev | Memory (RSS) |"
+    echo "|------|--------|---------|--------|--------|--------------|"
 
-    # FerrFlow rows
-    for j in "${!FERRFLOW_CMD_NAMES[@]}"; do
-      cmd_name="${FERRFLOW_CMD_NAMES[$j]}"
-      cmd="${FERRFLOW_CMDS[$j]}"
-      raw_file="$RAW_DIR/${fixture}-ferrflow-${cmd_name}.json"
-      mem_file="$RAW_DIR/${fixture}-ferrflow-${cmd_name}.mem"
-      if [[ ! -f "$raw_file" ]]; then continue; fi
-
-      median=$(extract_median "$raw_file")
-      stddev=$(extract_stddev "$raw_file")
-      mem=$(cat "$mem_file" 2>/dev/null || echo "N/A")
-
-      size_col="$FERRFLOW_BIN_SIZE MB"
-      if [[ "$FERRFLOW_NPM_SIZE" != "N/A" ]]; then
-        size_col="$FERRFLOW_BIN_SIZE MB / $FERRFLOW_NPM_SIZE MB (npm)"
-      fi
-
-      echo "| ferrflow | $cmd | ${median}ms | ${stddev}ms | $size_col | ${mem} MB |"
-    done
-
-    # Competitor rows
-    for tool in "semantic-release" "changesets"; do
-      raw_file="$RAW_DIR/${fixture}-${tool}-check.json"
-      mem_file="$RAW_DIR/${fixture}-${tool}-check.mem"
-      if [[ ! -f "$raw_file" ]]; then continue; fi
+    for raw_file in "$RAW_DIR/${fixture}"-*.json; do
+      [[ -f "$raw_file" ]] || continue
+      basename=$(basename "$raw_file" .json)
+      # Parse: fixture-tool-method-cmd
+      rest="${basename#"${fixture}-"}"
+      tool=$(echo "$rest" | cut -d'-' -f1)
+      method=$(echo "$rest" | cut -d'-' -f2)
+      cmd=$(echo "$rest" | cut -d'-' -f3-)
 
       median=$(extract_median "$raw_file" 2>/dev/null || echo "N/A")
       stddev=$(extract_stddev "$raw_file" 2>/dev/null || echo "N/A")
-      mem=$(cat "$mem_file" 2>/dev/null || echo "N/A")
-      npm_size=$(cat "$RAW_DIR/${tool}-npm-size.txt" 2>/dev/null || echo "N/A")
+      mem=$(cat "$RAW_DIR/${basename}.mem" 2>/dev/null || echo "N/A")
 
-      echo "| $tool | check | ${median}ms | ${stddev}ms | ${npm_size} MB | ${mem} MB |"
+      echo "| $tool | $method | $cmd | ${median}ms | ${stddev}ms | ${mem} MB |"
     done
   done
 fi

--- a/tools.json
+++ b/tools.json
@@ -1,0 +1,37 @@
+{
+  "ferrflow": {
+    "install_methods": {
+      "binary": {
+        "setup": null,
+        "command": "ferrflow"
+      },
+      "npm": {
+        "setup": "npm install -g ferrflow",
+        "command": "npx ferrflow"
+      },
+      "docker": {
+        "setup": "docker pull ghcr.io/ferrflow-org/ferrflow:latest",
+        "command": "docker run --rm -v $PWD:/repo -w /repo ghcr.io/ferrflow-org/ferrflow:latest"
+      }
+    },
+    "commands": ["check", "release --dry-run", "version", "tag"]
+  },
+  "semantic-release": {
+    "install_methods": {
+      "npm": {
+        "setup": "npm install -g semantic-release@23",
+        "command": "npx --yes semantic-release@23 --dry-run --no-ci"
+      }
+    },
+    "commands": [""]
+  },
+  "changesets": {
+    "install_methods": {
+      "npm": {
+        "setup": "npm install -g @changesets/cli",
+        "command": "npx --yes @changesets/cli status"
+      }
+    },
+    "commands": [""]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `tools.json` config defining tools, install methods, and commands
- `run.sh` reads tool configs from fixture definition files (`--definitions-dir`)
- Write per-tool config files into temp copies before benchmarking
- Remove hardcoded `setup_competitor_config()` function
- Support multiple install methods per tool (binary, npm, docker)
- ferrflow treated as a regular tool (not special-cased)
- Update `format-release.sh` and `compare.sh` for new key format

Closes #61