### PR TITLE
chore: enable skipCi in release commits

### DIFF
--- a/ferrflow.json
+++ b/ferrflow.json
@@ -3,7 +3,7 @@
   "workspace": {
     "tagTemplate": "v{version}",
     "floatingTags": ["major"],
-    "skipCi": false
+    "skipCi": true
   },
   "package": [
     {


### PR DESCRIPTION
## Summary
- Set `skipCi: true` to append `[skip ci]` to release commits, preventing redundant CI runs