### PR TITLE
fix: resolve competitor benchmark SKIP failures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -162,6 +162,8 @@ runs:
     - name: Run full benchmarks
       if: inputs.type == 'full' || inputs.type == 'all'
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.ferrflow-token }}
       run: |
         mkdir -p benchmarks/results
         ARGS="--fixtures-dir /tmp/bench-fixtures --results-dir benchmarks/results"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -267,6 +267,11 @@ for tool in $TOOLS; do
       else
         bare_remote=$(mktemp -d)
         setup_dummy_remote "$tmp_dir" "$bare_remote"
+
+        # changesets needs resolved node_modules to find workspaces
+        if [[ "$tool" == "changesets" && -f "$tmp_dir/package.json" ]]; then
+          (cd "$tmp_dir" && npm install --ignore-scripts --no-audit --no-fund &>/dev/null) || true
+        fi
       fi
 
       # Build commands to benchmark
@@ -288,6 +293,11 @@ for tool in $TOOLS; do
         raw_file="$RAW_DIR/${fixture}-${tool}-${method}-${cmd_name}.json"
 
         echo "  $label: $cmd on $fixture..." >&2
+
+        # semantic-release checks GITHUB_TOKEN even in --dry-run --no-ci
+        if [[ "$tool" == "semantic-release" ]]; then
+          export GITHUB_TOKEN="${GITHUB_TOKEN:-fake-token-for-benchmark}"
+        fi
 
         # Validate the command works before benchmarking
         if ! (cd "$tmp_dir" && eval "$full_cmd" >/dev/null 2>&1); then


### PR DESCRIPTION
## Summary
- Run `npm install` in fixture copy for changesets (needs resolved workspaces)
- Pass `GITHUB_TOKEN` to the benchmark step via `ferrflow-token` input (semantic-release checks it even in dry-run)
- Fallback to a fake token for local runs where no real token is available

Closes #74

## Test plan
- [ ] Trigger FerrFlow CI with `verbose: true` and verify changesets/semantic-release no longer SKIP
- [ ] If semantic-release still fails (GitHub API verification), that's acceptable — the benchmark primarily measures install size for competitors