### PR TITLE
fix(ci): remove debug telemetry step from release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,6 @@ jobs:
       - name: Record previous tag
         id: prev-tag
         run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
-      - name: Debug telemetry connectivity
-        run: |
-          echo "=== git remote ==="
-          git remote get-url origin
-          echo "=== curl api.ferrflow.com ==="
-          curl -sv --max-time 10 https://api.ferrflow.com/stats 2>&1 || true
-          echo "=== DNS resolve ==="
-          nslookup api.ferrflow.com || true
       - uses: FerrFlow-Org/ferrflow@v2
         with:
           dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
## Summary
- Remove the leftover "Debug telemetry connectivity" step from the CI release job that runs curl/nslookup against api.ferrflow.com on every release

Closes #68