### PR TITLE
fix: remove || true from hyperfine command to avoid timing failed runs

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -315,7 +315,7 @@ for tool in $TOOLS; do
           --runs "$RUNS" \
           --export-json "$raw_file" \
           --shell=bash \
-          "cd $tmp_dir && $full_cmd >/dev/null 2>&1 || true" \
+          "cd $tmp_dir && $full_cmd >/dev/null 2>&1" \
           2>/dev/null
 
         # Memory (single run)


### PR DESCRIPTION
## Summary
- Remove `|| true` from the hyperfine benchmarked command so that tool crashes during timed runs are reported as failures instead of silently recorded as successful

Closes #72