### PR TITLE
fix: warn when absolute threshold keys don't match any benchmark

### DIFF
--- a/scripts/compare.sh
+++ b/scripts/compare.sh
@@ -103,6 +103,7 @@ for key in "${!ABS_THRESHOLDS[@]}"; do
   new_median=$(jq -r ".benchmarks[\"$key\"].median_ms // empty" "$LATEST" 2>/dev/null || echo "")
 
   if [[ -z "$new_median" || "$new_median" == "null" ]]; then
+    echo "  WARN $key: absolute threshold defined but no matching benchmark found" >&2
     continue
   fi
 


### PR DESCRIPTION
## Summary
- Emit a warning to stderr when a hardcoded absolute threshold key in compare.sh doesn't match any entry in the results JSON, instead of silently skipping the check

Closes #71