### PR TITLE
feat: use equal warmup and runs for all tools with configurable inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Reusable GitHub Action for running FerrFlow benchmarks and detecting performance
 | `full-regression-threshold` | Relative threshold for full benchmark regressions (e.g. `125%`) | `125%` |
 | `binary-size-threshold` | Binary size growth threshold (e.g. `120%`) | `120%` |
 | `comment-on-pr` | Post benchmark results as PR comment | `true` |
+| `warmup` | Number of warmup runs before timing (hyperfine `--warmup`) | `3` |
+| `runs` | Number of timed runs (hyperfine `--runs`) | `10` |
 | `definitions` | Path to fixture definitions for benchmark generation | required |
 | `verbose` | Show full error output when a benchmark command fails validation | `false` |
 | `ferrflow-token` | GitHub token for PR comments and artifact access | required |

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,14 @@ inputs:
     description: 'Binary size growth threshold (e.g. 120%)'
     required: false
     default: '120%'
+  warmup:
+    description: 'Number of warmup runs before timing (hyperfine --warmup)'
+    required: false
+    default: '3'
+  runs:
+    description: 'Number of timed runs (hyperfine --runs)'
+    required: false
+    default: '10'
   definitions:
     description: 'Path to TOML definitions for benchmark fixture generation'
     required: true
@@ -168,6 +176,7 @@ runs:
         mkdir -p benchmarks/results
         ARGS="--fixtures-dir /tmp/bench-fixtures --results-dir benchmarks/results"
         ARGS="$ARGS --definitions-dir ${{ inputs.definitions }}"
+        ARGS="$ARGS --warmup ${{ inputs.warmup }} --runs ${{ inputs.runs }}"
         if [[ "${{ inputs.skip-competitors }}" == "true" ]]; then
           ARGS="$ARGS --skip-competitors"
         fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 # FerrFlow Benchmark Runner (hyperfine)
 #
-# Usage: ./run.sh [--json] [--skip-competitors] [--fixtures-dir <path>]
-#                 [--results-dir <path>] [--definitions-dir <path>]
+# Usage: ./run.sh [--json] [--skip-competitors] [--warmup <n>] [--runs <n>]
+#                 [--fixtures-dir <path>] [--results-dir <path>]
+#                 [--definitions-dir <path>]
 #
 # Requires: ferrflow, hyperfine, jq
 
@@ -25,6 +26,8 @@ while [[ $# -gt 0 ]]; do
     --json) OUTPUT_FORMAT="json"; shift ;;
     --skip-competitors) SKIP_COMPETITORS=true; shift ;;
     --verbose) VERBOSE=true; shift ;;
+    --warmup) WARMUP="$2"; shift 2 ;;
+    --runs) RUNS="$2"; shift 2 ;;
     --fixtures-dir) FIXTURES_DIR="$2"; shift 2 ;;
     --results-dir) RESULTS_DIR="$2"; shift 2 ;;
     --definitions-dir) DEFINITIONS_DIR="$2"; shift 2 ;;


### PR DESCRIPTION
## Summary
- All tools (ferrflow and competitors) now share the same `--warmup` and `--runs` values for fair comparison
- Add `warmup` and `runs` action inputs so consumers can tune the tradeoff between accuracy and CI time
- Add `--warmup` and `--runs` CLI flags to run.sh

Closes #24