### PR TITLE
feat: add validate command to ferrflow benchmarks

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -14,7 +14,7 @@
         "command": "docker run --rm --user $(id -u):$(id -g) -v $PWD:/repo -w /repo ghcr.io/ferrflow-org/ferrflow:latest"
       }
     },
-    "commands": ["check", "release --dry-run", "version", "tag"]
+    "commands": ["check", "release --dry-run", "version", "tag", "validate"]
   },
   "semantic-release": {
     "install_methods": {


### PR DESCRIPTION
## Summary
- Add `validate` to the list of benchmarked ferrflow commands in tools.json
- The remaining items in the issue (criterion micro-benchmarks for tag/git operations, larger fixture sizes, commit history variants) require changes in the ferrflow and Fixtures repos respectively

Partially addresses #47