### PR TITLE
fix: validate memory measurement is numeric before display

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -120,8 +120,14 @@ setup_dummy_remote() {
 
 # Measure peak RSS in MB (Linux only)
 measure_memory() {
-  if [[ "$(uname)" == "Linux" ]]; then
-    /usr/bin/time -v "$@" 2>&1 >/dev/null | grep "Maximum resident" | awk '{print $6}' | awk '{printf "%.1f", $1/1024}'
+  if [[ "$(uname)" != "Linux" ]] || ! command -v /usr/bin/time &>/dev/null; then
+    echo "N/A"
+    return
+  fi
+  local raw
+  raw=$(/usr/bin/time -v "$@" 2>&1 >/dev/null | grep "Maximum resident" | awk '{print $6}')
+  if [[ -n "$raw" && "$raw" =~ ^[0-9]+$ ]]; then
+    awk "BEGIN {printf \"%.1f\", $raw/1024}"
   else
     echo "N/A"
   fi
@@ -463,7 +469,7 @@ else
             row="$row ${median}ms |"
             # Use memory from any command (they share the same peak RSS roughly)
             m=$(cat "$RAW_DIR/${fixture}-${tool}-${method}-${cmd}.mem" 2>/dev/null || echo "")
-            [[ -n "$m" && "$m" != "N/A" ]] && mem="$m"
+            [[ -n "$m" && "$m" =~ ^[0-9]+\.?[0-9]*$ ]] && mem="$m"
           else
             row="$row - |"
           fi


### PR DESCRIPTION
## Summary
- Fix `measure_memory` to check `/usr/bin/time` exists before calling it
- Validate extracted RSS value is numeric before formatting
- In markdown output, only accept `.mem` values matching `^[0-9]+\.?[0-9]*$`
- Prevents `46.6N/A MB` display when memory measurement partially fails in Docker

## Test plan
- [ ] Run benchmarks in Docker environment
- [x] Shellcheck clean