### PR TITLE
fix(micro): filter orphan 'bench:' lines before piping to benchmark-action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,19 @@ runs:
     - name: Run micro benchmarks
       if: inputs.type == 'micro' || inputs.type == 'all'
       shell: bash
-      run: cargo bench --bench ferrflow_benchmarks -- --output-format bencher 2>/dev/null | tee output.txt
+      # Criterion's bencher-format output occasionally emits orphan
+      # `bench: XYZ ns/iter (...)` lines — no preceding `test <name> ...`
+      # prefix. benchmark-action/github-action-benchmark blows up on those
+      # with exit 101. Filter to only keep the well-formed
+      # `test <name> ... bench: N ns/iter (+/- M)` rows, which is all the
+      # action needs anyway.
+      run: |
+        set -o pipefail
+        cargo bench --bench ferrflow_benchmarks -- --output-format bencher 2>/dev/null | tee raw-output.txt
+        grep -E '^test .+ \.\.\. bench:[[:space:]]+[0-9,]+ ns/iter' raw-output.txt > output.txt
+        echo "---"
+        echo "Filtered bencher output ($(wc -l < output.txt) lines kept):"
+        cat output.txt
 
     - name: Find baseline artifact from main
       if: (inputs.type == 'micro' || inputs.type == 'all') && github.event_name == 'pull_request'


### PR DESCRIPTION
## Problem

Every FerrFlow PR has been failing \`Micro Benchmarks\` lately with exit 101. Root cause: criterion's \`--output-format bencher\` emits a handful of orphan lines:

\`\`\`
bench:     158,352 ns/iter (+/- 5,760)
\`\`\`

No \`test <name> ...\` prefix. \`benchmark-action/github-action-benchmark\` sees them and panics on parse.

## Fix

Filter \`output.txt\` to only the well-formed rows the action actually consumes:

\`\`\`
grep -E '^test .+ \.\.\. bench:[[:space:]]+[0-9,]+ ns/iter' raw-output.txt > output.txt
\`\`\`

Lossless — the comparison step reads no other line types.

Also prints the filtered output to the job log so the next time it goes sideways the raw vs filtered diff is inspectable.

## Test plan

- [ ] Re-run any recent failing PR job after this merges (e.g. FerrFlow PR #368) and confirm Micro Benchmarks goes green.