### PR TITLE
fix(ci): rebrand GHCR + GitHub URLs from ferrflow-org to ferrlabs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Record previous tag
         id: prev-tag
         run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
-      - uses: FerrFlow-Org/ferrflow@v3
+      - uses: FerrLabs/ferrflow@v3
         with:
           dry_run: ${{ inputs.dry_run }}
         env:
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/checkout@v6
         with:
-          repository: FerrFlow-Org/ferrflow
+          repository: FerrLabs/ferrflow
           path: ferrflow-src
           token: ${{ secrets.FERRFLOW_TOKEN }}
       - uses: dtolnay/rust-toolchain@nightly
@@ -90,7 +90,7 @@ jobs:
       - name: Add ferrflow to PATH
         run: echo "${{ github.workspace }}/ferrflow-src/target/release" >> "$GITHUB_PATH"
       - name: Generate benchmark fixtures
-        uses: FerrFlow-Org/Fixtures@v0
+        uses: FerrLabs/Fixtures@v0
         with:
           definitions: ferrflow-src/benchmarks/fixtures/definitions
           generated-dir: /tmp/bench-fixtures

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # FerrFlow Benchmarks
 
-[![CI](https://github.com/FerrFlow-Org/Benchmarks/actions/workflows/ci.yml/badge.svg)](https://github.com/FerrFlow-Org/Benchmarks/actions/workflows/ci.yml)
-[![License](https://img.shields.io/github/license/FerrFlow-Org/Benchmarks)](LICENSE)
+[![CI](https://github.com/FerrLabs/Benchmarks/actions/workflows/ci.yml/badge.svg)](https://github.com/FerrLabs/Benchmarks/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/FerrLabs/Benchmarks)](LICENSE)
 
 Reusable GitHub Action for running FerrFlow benchmarks and detecting performance regressions.
 
 ## Usage
 
 ```yaml
-- uses: FerrFlow-Org/Benchmarks@v2
+- uses: FerrLabs/Benchmarks@v2
   with:
     type: micro        # micro, full, or all
     ferrflow-token: ${{ secrets.FERRFLOW_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Only the latest release receives security updates.
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/FerrFlow-Org/Benchmarks/security/advisories/new).
+If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/FerrLabs/Benchmarks/security/advisories/new).
 
 Do **not** open a public issue for security vulnerabilities.
 

--- a/action.yml
+++ b/action.yml
@@ -188,7 +188,7 @@ runs:
 
     - name: Generate benchmark fixtures
       if: inputs.type == 'full' || inputs.type == 'all'
-      uses: FerrFlow-Org/Fixtures@v0
+      uses: FerrLabs/Fixtures@v0
       with:
         definitions: ${{ inputs.definitions }}
         generated-dir: /tmp/bench-fixtures

--- a/tools.json
+++ b/tools.json
@@ -10,8 +10,8 @@
         "command": "npx ferrflow"
       },
       "docker": {
-        "setup": "docker pull ghcr.io/ferrflow-org/ferrflow:latest",
-        "command": "docker run --rm --user $(id -u):$(id -g) -v $PWD:/repo -w /repo ghcr.io/ferrflow-org/ferrflow:latest"
+        "setup": "docker pull ghcr.io/ferrlabs/ferrflow:latest",
+        "command": "docker run --rm --user $(id -u):$(id -g) -v $PWD:/repo -w /repo ghcr.io/ferrlabs/ferrflow:latest"
       }
     },
     "commands": ["check", "release --dry-run", "version", "tag", "validate"]


### PR DESCRIPTION
Bulk URL update: `ferrflow-org/` → `ferrlabs/`, `FerrFlow-Org/` → `FerrLabs/`. Skips CHANGELOG and lockfiles. Mirrors [FerrFlow-Cloud#376](https://github.com/FerrLabs/FerrFlow-Cloud/pull/376).