### PR TITLE
feat(action): add group-filter input to support matrix sharding

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
   ferrflow-token:
     description: 'GitHub token for PR comments and artifact access'
     required: true
+  group-filter:
+    description: 'Optional criterion bench group filter (substring). If set, only benches matching this are run. Use for matrix sharding.'
+    required: false
+    default: ''
 
 outputs:
   regression-detected:
@@ -83,8 +87,12 @@ runs:
       # the step if NO well-formed rows got captured.
       run: |
         set +e
-        cargo bench --bench ferrflow_benchmarks -- --output-format bencher \
-          2> bench-stderr.log | tee raw-output.txt
+        GROUP_FILTER="${{ inputs.group-filter }}"
+        BENCH_ARGS=(--bench ferrflow_benchmarks -- --output-format bencher)
+        if [ -n "$GROUP_FILTER" ]; then
+          BENCH_ARGS+=(--filter "$GROUP_FILTER")
+        fi
+        cargo bench "${BENCH_ARGS[@]}" 2> bench-stderr.log | tee raw-output.txt
         bench_exit=${PIPESTATUS[0]}
         set -e
         if [ "$bench_exit" != "0" ]; then


### PR DESCRIPTION
Adds an optional `group-filter` input to forward `--filter <substr>` to `cargo bench`. When set, criterion only runs bench IDs matching the substring, enabling matrix sharding of micro benchmarks across runners without changing measurement precision.

No change to default behavior (filter empty → full run).

## Test plan
- [ ] FerrFlow caller workflow runs micro benchmarks in matrix mode and aggregates results without regressions