### PR TITLE
fix(action): pass criterion group-filter as positional arg

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,8 @@ runs:
         GROUP_FILTER="${{ inputs.group-filter }}"
         BENCH_ARGS=(--bench ferrflow_benchmarks -- --output-format bencher)
         if [ -n "$GROUP_FILTER" ]; then
-          BENCH_ARGS+=(--filter "$GROUP_FILTER")
+          # criterion takes the filter as a positional arg, not --filter
+          BENCH_ARGS+=("$GROUP_FILTER")
         fi
         cargo bench "${BENCH_ARGS[@]}" 2> bench-stderr.log | tee raw-output.txt
         bench_exit=${PIPESTATUS[0]}


### PR DESCRIPTION
criterion's CLI takes the filter as positional `[FILTER]`, not `--filter <name>`. Drop the flag.