### PR TITLE
fix(action): skip compare+comment when comment-on-pr is false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,8 @@ runs:
         GROUP_FILTER="${{ inputs.group-filter }}"
         BENCH_ARGS=(--bench ferrflow_benchmarks -- --output-format bencher)
         if [ -n "$GROUP_FILTER" ]; then
-          BENCH_ARGS+=(--filter "$GROUP_FILTER")
+          # criterion takes the filter as a positional arg, not --filter
+          BENCH_ARGS+=("$GROUP_FILTER")
         fi
         cargo bench "${BENCH_ARGS[@]}" 2> bench-stderr.log | tee raw-output.txt
         bench_exit=${PIPESTATUS[0]}

--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,13 @@ runs:
         fi
 
     - name: Compare and comment (PR)
-      if: (inputs.type == 'micro' || inputs.type == 'all') && github.event_name == 'pull_request'
+      # Skip the compare+comment step entirely when the caller disables PR
+      # commenting (matrix shards set comment-on-pr: false — an aggregate job
+      # merges all shard outputs and runs the comparison once with proper
+      # pull-requests: write permission). Keeping this step here would fail
+      # on regression alerts because matrixed jobs don't have permission to
+      # post PR reviews.
+      if: (inputs.type == 'micro' || inputs.type == 'all') && github.event_name == 'pull_request' && inputs.comment-on-pr == 'true'
       uses: benchmark-action/github-action-benchmark@v1
       with:
         tool: cargo


### PR DESCRIPTION
Matrix callers set `comment-on-pr: false` and do the comparison in an aggregate job. The inline compare step was still running and failing on regression alerts (no PR-review permission on matrixed jobs). Gate it on `inputs.comment-on-pr == 'true'`.