### PR TITLE
ci: switch release to ferrflow[bot] via OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,22 +38,20 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
+      id-token: write
     outputs:
       tag: ${{ steps.detect-tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.FERRFLOW_TOKEN }}
       - name: Record previous tag
         id: prev-tag
         run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
-      - uses: FerrLabs/ferrflow@v3
+      - uses: FerrLabs/FerrFlow@v4
         with:
+          bot: true
           dry_run: ${{ inputs.dry_run }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
-          FERRFLOW_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
       - name: Detect new tag
         id: detect-tag
         run: |
@@ -72,9 +70,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/checkout@v6
         with:
-          repository: FerrLabs/ferrflow
+          repository: FerrLabs/FerrFlow
           path: ferrflow-src
-          token: ${{ secrets.FERRFLOW_TOKEN }}
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
         with:
@@ -133,4 +130,4 @@ jobs:
           printf -v NEW_BODY '%s\n\n%s' "$CURRENT_BODY" "$PERF"
           gh release edit "$TAG" --notes "$NEW_BODY"
         env:
-          GH_TOKEN: ${{ secrets.FERRFLOW_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switches the release job to the hosted ferrflow[bot] identity via OIDC, removing the FERRFLOW_TOKEN PAT dependency. Bumps to FerrLabs/FerrFlow@v4, adds id-token: write, and routes downstream gh release edit through the default GITHUB_TOKEN. The ferrflow App is already installed on the FerrLabs org; FERRFLOW_TOKEN can be deleted after merge.