### PR TITLE
ci: add openssf scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,50 @@
+name: OSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 3 * * 1'   # weekly, Monday 03:00 UTC
+  push:
+    branches: [main]
+
+# Declare default permissions as read only at the workflow level.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for publishing results to the GitHub code scanning dashboard.
+      security-events: write
+      # Required for Scorecard workflow to fetch repository metadata.
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # publish_results: true publishes to scorecard.dev which backs the
+          # public badge URL used in the README.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FerrFlow Benchmarks
 
 [![License](https://img.shields.io/github/license/FerrLabs/Benchmarks)](LICENSE)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/FerrLabs/Benchmarks/badge)](https://scorecard.dev/viewer/?uri=github.com/FerrLabs/Benchmarks)
 
 Reusable GitHub Action for running FerrFlow benchmarks and detecting performance regressions.
 


### PR DESCRIPTION
Adds the OpenSSF Scorecard analysis workflow and README badge. Runs on push to main and weekly (Monday 03:00 UTC), publishes results to scorecard.dev.