### PR TITLE
chore(renovate): extend shared FerrLabs preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "rebaseWhen": "behind-base-branch",
-  "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "groupName": "GitHub Actions"
-    }
-  ]
+  "extends": ["local>FerrLabs/.github"]
 }


### PR DESCRIPTION
Switches to the shared preset at `FerrLabs/.github/default.json`. See FerrLabs/.github#1.