### PR TITLE
chore(github): add PR template prompting for changelog entry

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- 1-3 bullets describing what this PR does and why -->
+
+## Public changelog
+
+<!--
+For ANY user-facing change (feature, fix, perf, breaking, deprecation, security),
+add a markdown file to FerrLabs-Cloud/site/src/content/changelog/ in this same PR:
+
+  YYYY-MM-DD-slug.md
+  ---
+  title: "Product · short headline"
+  summary: "One sentence."
+  date: YYYY-MM-DD
+  product: ferrflow|ferrvault|ferrtrack|ferrgrowth|ferragents|ferrlabs
+  type: new|fix|perf|breaking|deprecation|security
+  prLink: https://github.com/...      # optional
+  docsLink: https://...               # optional
+  ---
+
+  3-10 sentences. What + why + how to use. Code blocks welcome.
+
+Skip the changelog ONLY for: internal refactors, variable renames, type-only
+changes, CI/test/dev-tooling tweaks, doc-only typos, dependency bumps with no
+behaviour change.
+-->
+
+- [ ] Changelog entry added (or N/A — internal-only change)
+
+## Test plan
+
+<!-- How did you verify this works? -->


### PR DESCRIPTION
Adds a `.github/pull_request_template.md` that prompts every PR author to add an entry to the public changelog at https://ferrlabs.com/changelog/ when the change is user-facing. Includes the schema + skip rules so contributors don't have to dig into CLAUDE.md.