### PR TITLE
chore(workflows): migrate ubuntu-latest to ferrlabs-k8s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - name: ShellCheck
@@ -23,7 +23,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     steps:
       - uses: actions/checkout@v6
       - name: Install bats
@@ -34,7 +34,7 @@ jobs:
   release:
     name: Release
     needs: [lint, test]
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
@@ -64,7 +64,7 @@ jobs:
   benchmark:
     name: Benchmark
     needs: [lint, test]
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
@@ -110,7 +110,7 @@ jobs:
   update-release:
     name: Update release with benchmarks
     needs: [release, benchmark]
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     if: needs.release.outputs.tag != ''
     permissions:
       contents: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ferrlabs-k8s
     permissions:
       # Required for publishing results to the GitHub code scanning dashboard.
       security-events: write


### PR DESCRIPTION
Migrate every direct `runs-on: ubuntu-latest` to `runs-on: ferrlabs-k8s` (self-hosted Kubernetes runner) to stop burning GitHub Actions billing on private repos.

Matrix entries (`os: ubuntu-latest`) and `if: matrix.os == 'ubuntu-latest'` lines are intentionally preserved where present — they drive cross-compilation OS targets, not runner selection. Lines using `${{ inputs.runner }}` are also untouched (consumers pass `ferrlabs-k8s` already).

After merge, re-run failed CI on existing PRs via `gh run rerun --failed`.
