### PR TITLE
chore(hooks): mirror CI checks in pre-push hook

### DIFF
--- a/.githooks/install.sh
+++ b/.githooks/install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-push 2>/dev/null || true
+echo "Git hooks installed (core.hooksPath=.githooks)."
+echo "pre-push: shellcheck scripts/*.sh + bats tests/ (skipped if tools missing)"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v shellcheck >/dev/null 2>&1; then
+  echo "==> shellcheck scripts/*.sh"
+  shellcheck scripts/*.sh
+else
+  echo "(shellcheck not installed — skipping; CI will run it)"
+fi
+
+if command -v bats >/dev/null 2>&1; then
+  echo "==> bats tests/"
+  bats tests/
+else
+  echo "(bats not installed — skipping; CI will run it)"
+fi


### PR DESCRIPTION
## Summary

Adds `.githooks/pre-push` mirroring `.github/workflows/ci.yml`'s lint + test jobs.

`.githooks/pre-push` runs:
- `shellcheck scripts/*.sh` (mirrors `lint.ShellCheck`)
- `bats tests/` (mirrors `test.Run tests`)

Both steps gracefully no-op if the corresponding tool isn't installed (install via `brew install shellcheck bats-core` or distro equivalent).

To activate: run `bash .githooks/install.sh` once.

## Test plan
- [ ] `shellcheck scripts/*.sh` passes
- [ ] `bats tests/` passes
- [ ] `bash .githooks/install.sh` then `git push --dry-run` does not crash