### PR TITLE
chore(ci): use ubuntu-latest on public repos (free GitHub runners)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: ShellCheck
@@ -23,7 +23,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Install bats
@@ -34,7 +34,7 @@ jobs:
   release:
     name: Release
     needs: [lint, test]
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
@@ -64,7 +64,7 @@ jobs:
   benchmark:
     name: Benchmark
     needs: [lint, test]
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
@@ -110,7 +110,7 @@ jobs:
   update-release:
     name: Update release with benchmarks
     needs: [release, benchmark]
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     if: needs.release.outputs.tag != ''
     permissions:
       contents: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ferrlabs-k8s
+    runs-on: ubuntu-latest
     permissions:
       # Required for publishing results to the GitHub code scanning dashboard.
       security-events: write


### PR DESCRIPTION
Switch GitHub Actions workflows back from the self-hosted `ferrlabs-k8s` runner pool to GitHub's hosted `ubuntu-latest`. The runner migration was over-applied to public OSS repos — those should stay on GitHub-hosted runners.

Rationale:
- Public repos get unlimited free minutes on GitHub-hosted runners
- Stop burning self-hosted capacity for OSS workloads
- No infra dependency for OSS contributors / community PRs
- Match the standard GitHub-free-on-public model

The composite action (`action.yml`) inherits its runner from the caller and is unchanged.