### PR TITLE
feat: add standard-version and commit-and-tag-version to competitor benchmarks

### DIFF
--- a/scripts/format-release.sh
+++ b/scripts/format-release.sh
@@ -41,7 +41,7 @@ declare -A BENCH_DATA BENCH_MEM
 
 while IFS= read -r key; do
   fixture="" tool="" method="" cmd=""
-  for t in semantic-release release-please changesets ferrflow; do
+  for t in commit-and-tag-version standard-version semantic-release release-please changesets ferrflow; do
     if [[ "$key" == *"-${t}-"* ]]; then
       tool="$t"
       fixture="${key%%-"$t"-*}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -410,7 +410,7 @@ else
         print $2
       }')
       # Parse: tool-method-cmd (tool may be multi-part like semantic-release)
-      for t in semantic-release release-please changesets ferrflow; do
+      for t in commit-and-tag-version standard-version semantic-release release-please changesets ferrflow; do
         if [[ "$rest" == "${t}-"* ]]; then
           after="${rest#"${t}-"}"
           method="${after%%-*}"
@@ -451,7 +451,7 @@ else
         [[ -f "$raw_file" ]] || continue
         bname=$(basename "$raw_file" .json)
         rest="${bname#"${fixture}-"}"
-        for t in semantic-release release-please changesets ferrflow; do
+        for t in commit-and-tag-version standard-version semantic-release release-please changesets ferrflow; do
           if [[ "$rest" == "${t}-${method}-"* || "$rest" == "${t}-${method}" ]]; then
             TOOL_ROWS[$t]=1
             break

--- a/tools.json
+++ b/tools.json
@@ -33,5 +33,23 @@
       }
     },
     "commands": [""]
+  },
+  "standard-version": {
+    "install_methods": {
+      "npm": {
+        "setup": "npm install -g standard-version",
+        "command": "npx --yes standard-version --dry-run"
+      }
+    },
+    "commands": [""]
+  },
+  "commit-and-tag-version": {
+    "install_methods": {
+      "npm": {
+        "setup": "npm install -g commit-and-tag-version",
+        "command": "npx --yes commit-and-tag-version --dry-run"
+      }
+    },
+    "commands": [""]
   }
 }


### PR DESCRIPTION
Adds two more npm-installed conventional-commit release tools to the comparison roster so the benchmark table has fuller coverage of the JS ecosystem.

## New entries in `tools.json`

| Tool | Setup | Command |
|---|---|---|
| `standard-version` | `npm install -g standard-version` | `npx --yes standard-version --dry-run` |
| `commit-and-tag-version` | `npm install -g commit-and-tag-version` | `npx --yes commit-and-tag-version --dry-run` |

Both are pure-npx tools (no GitHub API dependency like release-please needs), so they slot directly into the existing `run.sh` flow.

## Parser update

`scripts/run.sh` and `scripts/format-release.sh` have a hardcoded ordered list of known tool names (used for splitting benchmark keys like `mono-100-1k-<tool>-<method>-<cmd>`). Order matters because the parser uses longest-prefix match: `commit-and-tag-version` and `standard-version` must appear before single-token names. Updated both files accordingly.

## Triggering

Lands automatically in the next FerrFlow benchmark run that consumes `Benchmarks@v3` with `skip-competitors: false` (FerrFlow#451).