### PR TITLE
feat(run): aggregate install_sizes from per-tool size files

### DIFF
--- a/scripts/format-release.sh
+++ b/scripts/format-release.sh
@@ -119,4 +119,21 @@ for method in $(printf '%s\n' "${!ALL_METHODS[@]}" | sort); do
   echo ""
 done
 
+has_install_sizes=$(jq -r 'if has("install_sizes") and (.install_sizes | length > 0) then "yes" else "no" end' "$LATEST")
+if [[ "$has_install_sizes" == "yes" ]]; then
+  echo ""
+  echo "### Install footprint"
+  echo ""
+  echo "| Tool | npm | binary |"
+  echo "|------|-----|--------|"
+  while IFS= read -r tool; do
+    npm_size=$(jq -r --arg t "$tool" '.install_sizes[$t].npm // "—"' "$LATEST")
+    bin_size=$(jq -r --arg t "$tool" '.install_sizes[$t].binary // "—"' "$LATEST")
+    [[ "$npm_size" != "—" ]] && npm_size="${npm_size} MB"
+    [[ "$bin_size" != "—" ]] && bin_size="${bin_size} MB"
+    echo "| ${tool} | ${npm_size} | ${bin_size} |"
+  done < <(jq -r '.install_sizes | keys[]' "$LATEST" | sort)
+  echo ""
+fi
+
 echo "*Binary size: ${BINARY_SIZE} MB — ferrflow ${VERSION}*"

--- a/scripts/format-release.sh
+++ b/scripts/format-release.sh
@@ -29,9 +29,6 @@ if ! command -v jq &>/dev/null; then
   exit 1
 fi
 
-VERSION=$(jq -r '.ferrflow_version' "$LATEST")
-BINARY_SIZE=$(jq -r '.ferrflow_binary_size_mb' "$LATEST")
-
 echo "## Performance"
 echo ""
 
@@ -135,5 +132,3 @@ if [[ "$has_install_sizes" == "yes" ]]; then
   done < <(jq -r '.install_sizes | keys[]' "$LATEST" | sort)
   echo ""
 fi
-
-echo "*Binary size: ${BINARY_SIZE} MB — ferrflow ${VERSION}*"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -371,18 +371,36 @@ for raw_file in "$RAW_DIR"/*.json; do
     '.[$k] = {median_ms: $median, stddev_ms: $stddev, memory_mb: $mem}')
 done
 
+INSTALL_SIZES_OBJ='{}'
+for size_file in "$RAW_DIR"/*-size.txt; do
+  [[ -f "$size_file" ]] || continue
+  bname=$(basename "$size_file" .txt)
+  if [[ "$bname" =~ ^(.+)-(npm|binary)-size$ ]]; then
+    tool="${BASH_REMATCH[1]}"
+    method="${BASH_REMATCH[2]}"
+    size_val=$(cat "$size_file")
+    INSTALL_SIZES_OBJ=$(echo "$INSTALL_SIZES_OBJ" | jq \
+      --arg t "$tool" \
+      --arg m "$method" \
+      --arg v "$size_val" \
+      '.[$t] = ((.[$t] // {}) + {($m): $v})')
+  fi
+done
+
 jq -n \
   --arg ts "$TIMESTAMP" \
   --arg ver "$FERRFLOW_VERSION" \
   --arg bin "$FERRFLOW_BIN_SIZE" \
   --arg npm "$FERRFLOW_NPM_SIZE" \
   --argjson benchmarks "$BENCHMARKS_OBJ" \
+  --argjson install_sizes "$INSTALL_SIZES_OBJ" \
   '{
     timestamp: $ts,
     ferrflow_version: $ver,
     ferrflow_binary_size_mb: $bin,
     ferrflow_npm_size_mb: $npm,
-    benchmarks: $benchmarks
+    benchmarks: $benchmarks,
+    install_sizes: $install_sizes
   }' > "$RESULTS_DIR/latest.json"
 
 echo "" >&2

--- a/tests/format-release.bats
+++ b/tests/format-release.bats
@@ -97,6 +97,47 @@ EOF
   [[ "$output" == *"### Npm"* ]]
 }
 
+@test "renders install footprint when install_sizes present" {
+  cat > "$TMPDIR/latest.json" <<'EOF'
+{
+  "ferrflow_version": "2.5.0",
+  "ferrflow_binary_size_mb": "5.2",
+  "ferrflow_npm_size_mb": "1.1",
+  "benchmarks": {
+    "single-ferrflow-binary-check": {"median_ms": 14.7, "stddev_ms": 0.5, "memory_mb": "12.4"}
+  },
+  "install_sizes": {
+    "ferrflow": {"binary": "5.2", "npm": "1.1"},
+    "release-please": {"npm": "38.1"},
+    "changesets": {"npm": "12.4"}
+  }
+}
+EOF
+
+  run bash "$SCRIPT_DIR/format-release.sh" "$TMPDIR/latest.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"### Install footprint"* ]]
+  [[ "$output" == *"| release-please | 38.1 MB | — |"* ]]
+  [[ "$output" == *"| ferrflow | 1.1 MB | 5.2 MB |"* ]]
+}
+
+@test "skips install footprint when install_sizes missing" {
+  cat > "$TMPDIR/latest.json" <<'EOF'
+{
+  "ferrflow_version": "2.5.0",
+  "ferrflow_binary_size_mb": "5.2",
+  "ferrflow_npm_size_mb": "N/A",
+  "benchmarks": {
+    "single-ferrflow-binary-check": {"median_ms": 14.7, "stddev_ms": 0.5, "memory_mb": "12.4"}
+  }
+}
+EOF
+
+  run bash "$SCRIPT_DIR/format-release.sh" "$TMPDIR/latest.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Install footprint"* ]]
+}
+
 @test "handles empty benchmarks" {
   cat > "$TMPDIR/latest.json" <<'EOF'
 {

--- a/tests/format-release.bats
+++ b/tests/format-release.bats
@@ -33,7 +33,7 @@ EOF
   [[ "$output" == *"12.4 MB"* ]]
 }
 
-@test "shows binary size and version in footer" {
+@test "does not emit redundant binary-size footer" {
   cat > "$TMPDIR/latest.json" <<'EOF'
 {
   "ferrflow_version": "2.5.0",
@@ -47,8 +47,13 @@ EOF
 
   run bash "$SCRIPT_DIR/format-release.sh" "$TMPDIR/latest.json"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Binary size: 5.2 MB"* ]]
-  [[ "$output" == *"ferrflow 2.5.0"* ]]
+  # Footer removed: the bench artifact's ferrflow_version is captured BEFORE
+  # the release commit bumps the version, so it was always stale (e.g.
+  # 4.8.1 in a 4.9.0 release). Binary size from the CI build also overstates
+  # the real download. The Install footprint section is the canonical place
+  # for size now; the release page already shows the version in its title.
+  [[ "$output" != *"Binary size:"* ]]
+  [[ "$output" != *"ferrflow 2.5.0"* ]]
 }
 
 @test "shows delta percentages with baseline" {
@@ -151,7 +156,6 @@ EOF
   run bash "$SCRIPT_DIR/format-release.sh" "$TMPDIR/latest.json"
   [ "$status" -eq 0 ]
   [[ "$output" == *"## Performance"* ]]
-  [[ "$output" == *"Binary size: N/A MB"* ]]
 }
 
 @test "exits 1 with no arguments" {


### PR DESCRIPTION
Closes #116.

`run.sh` already writes `<tool>-{npm,binary}-size.txt` for every tool it touches (the release-please block at the end of the script is a special case but writes the same file shape). Aggregation only read ferrflow's though — every other size was silently dropped on the floor.

This PR plumbs them all the way through.

## What's in the JSON

`latest.json` gains an `install_sizes` field:

\`\`\`json
"install_sizes": {
  "ferrflow":               {"binary": "17.0", "npm": "17.0"},
  "changesets":             {"npm": "12.4"},
  "commit-and-tag-version": {"npm": "8.1"},
  "release-please":         {"npm": "38.1"},
  "semantic-release":       {"npm": "45.2"},
  "standard-version":       {"npm": "8.1"}
}
\`\`\`

`release-please` matters here because it requires the GitHub API to resolve the latest release — there's no offline `--dry-run` we can hyperfine fairly. Footprint is the only comparison we can publish for it.

## Release notes

`format-release.sh` appends a new "### Install footprint" subsection under `## Performance` whenever `install_sizes` is non-empty:

\`\`\`
### Install footprint

| Tool                    | npm     | binary  |
|-------------------------|---------|---------|
| changesets              | 12.4 MB | —       |
| commit-and-tag-version  | 8.1 MB  | —       |
| ferrflow                | 1.1 MB  | 5.2 MB  |
| release-please          | 38.1 MB | —       |
| semantic-release        | 45.2 MB | —       |
| standard-version        | 8.1 MB  | —       |
\`\`\`

Backward compat: when reading an old `latest.json` without `install_sizes`, the subsection is skipped.

## Test plan

- [x] New bats: `renders install footprint when install_sizes present` asserts the section and the release-please / ferrflow rows
- [x] New bats: `skips install footprint when install_sizes missing` covers the legacy-data path
- [x] Existing bats still green (additive change to format-release.sh; new field on latest.json)
- [ ] Manual smoke on the next FerrFlow release: `latest.json` in the `hyperfine-baseline` artifact contains `install_sizes`, release notes show the new subsection
- [ ] Once merged, ferrflow.com/performance picks the new field up via [FerrLabs/FerrFlow-Cloud sync](https://github.com/FerrLabs/FerrFlow-Cloud/blob/main/.github/workflows/sync-ferrflow.yml) and renders the Install footprint section (separate PR)