### PR TITLE
fix(release): switch to PR mode so branch-protected main accepts auto-releases

### DIFF
--- a/ferrflow.json
+++ b/ferrflow.json
@@ -3,7 +3,9 @@
   "workspace": {
     "tagTemplate": "v{version}",
     "floatingTags": ["major"],
-    "skipCi": false
+    "skipCi": false,
+    "releaseCommitMode": "pr",
+    "autoMergeReleases": true
   },
   "package": [
     {


### PR DESCRIPTION
Closes #119.

## Why

ferrflow[bot] has been blocked from pushing the release commit to \`main\` since at least April 22 (last successful auto-release: v3.1.2). Every push hits:

\`\`\`
Push rejected (non-fast-forward), rebasing on remote and retrying (1/3)...
Push rejected (non-fast-forward), rebasing on remote and retrying (2/3)...
error[E2004]: Failed to push branch 'main' after 3 attempt(s)
E2005: Push rejected by remote: refs/heads/main: push declined due to repository rule violations
\`\`\`

The branch protection rule on \`main\` doesn't include ferrflow[bot] in its bypass list. Adding the bot to the bypass list would also work (one-click admin action) but couples the release flow to repo settings that aren't checked in. Switching to PR mode is the universal fallback that survives any branch protection setup.

v4 had to be tagged by hand for this reason. With this PR landed, the next time a meaningful commit lands on main (feat:/fix:), FerrFlow will:

1. Generate the chore(release): commit on a feature branch
2. Open a PR
3. Auto-merge it once the required status checks pass

No manual intervention.

## What changes

Adding two fields to the workspace config in \`ferrflow.json\`:

\`\`\`json
\"releaseCommitMode\": \"pr\",
\"autoMergeReleases\": true
\`\`\`

\`autoMergeReleases\` defaults to true per the [schema](https://ferrflow.com/schema/ferrflow.json) but I'm setting it explicitly so the intent is grep-able when someone reads the config later.

## Test plan

- [ ] Merge this PR
- [ ] Make any meaningful commit on main (or wait for one)
- [ ] Verify ferrflow[bot] opens a release PR + GitHub auto-merges it
- [ ] Tag is created normally → docker.yml fires → consumers (FerrFlow ci.yml) pick up the new version