### PR TITLE
fix: base64-encode tool_configs values so multi-line content survives read

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -68,16 +68,21 @@ write_tool_configs() {
     return
   fi
 
-  # Extract tool_configs.<tool> and write each file
-  local files
-  files=$(jq -r --arg t "$tool" '.tool_configs[$t] // {} | to_entries[] | "\(.key)\t\(.value)"' "$def_file" 2>/dev/null) || return 0
+  # Emit each entry as "<path>\t<base64-content>\n". Base64 collapses
+  # any multi-line content (e.g. changesets frontmatter with embedded
+  # newlines) into a single line so `read -r` captures it intact instead
+  # of stopping at the first \n.
+  local entries
+  entries=$(jq -r --arg t "$tool" \
+    '.tool_configs[$t] // {} | to_entries[] | "\(.key)\t" + (.value | @base64)' \
+    "$def_file" 2>/dev/null) || return 0
 
-  while IFS=$'\t' read -r path content; do
+  while IFS=$'\t' read -r path b64; do
     [[ -z "$path" ]] && continue
     local full_path="$target_dir/$path"
     mkdir -p "$(dirname "$full_path")"
-    echo "$content" > "$full_path"
-  done <<< "$files"
+    printf '%s' "$b64" | base64 -d > "$full_path"
+  done <<< "$entries"
 }
 
 # Auto-generate ferrflow config for bulk fixtures with empty config


### PR DESCRIPTION
Closes #124

## Summary

\`write_tool_configs\` in \`scripts/run.sh\` piped jq's \`<path>\t<value>\` output into \`while IFS=\$'\t' read -r path content\`. \`read -r\` stops at the first newline, so any tool_config value with embedded newlines got truncated to its first line. Most visible: every changesets fixture failed with \`could not parse changeset - missing or invalid frontmatter\` because the \`.changeset/*.md\` file ended up as just \`---\n\`.

## Fix

jq emits each value base64-encoded so the entry is always a single line:

\`\`\`
.tool_configs[\$t] // {} | to_entries[] | "\(.key)\t" + (.value | @base64)
\`\`\`

The shell decodes after \`read\` and \`printf | base64 -d > \$file\`. Behavior is identical for single-line values; now correct for multi-line ones (changesets, multi-line release-please configs, etc.).

## Test plan

- [x] diff is minimal (only \`write_tool_configs\`)
- [ ] CI: changesets row stops being SKIPped in the next bench run