### PR TITLE
docs(format): explain why Binary/Docker sections only show ferrflow

### DIFF
--- a/scripts/format-release.sh
+++ b/scripts/format-release.sh
@@ -95,6 +95,14 @@ for method in $(printf '%s\n' "${!ALL_METHODS[@]}" | sort); do
   echo "$header"
   echo "$separator"
 
+  # Track tools that produced data in this method's section so we can
+  # add a transparency note when only ferrflow has rows (typical for
+  # `binary` and `docker`, since every competitor is a Node package
+  # with no native binary or first-party Docker image to compare
+  # against). Otherwise the empty sections look like a competitor's
+  # data was lost or filtered out, when in reality there's nothing to
+  # measure.
+  declare -A METHOD_TOOLS_WITH_DATA=()
   for fixture in "${FIXTURE_LIST[@]}"; do
     for tool in $(printf '%s\n' "${!ALL_TOOLS[@]}" | sort); do
       has_data=false
@@ -110,9 +118,29 @@ for method in $(printf '%s\n' "${!ALL_METHODS[@]}" | sort); do
       done
       mem="${BENCH_MEM["${fixture}|${tool}|${method}"]:-N/A}"
       row="$row $mem |"
-      $has_data && echo "$row"
+      if $has_data; then
+        echo "$row"
+        METHOD_TOOLS_WITH_DATA[$tool]=1
+      fi
     done
   done
+
+  case "$method" in
+    binary)
+      if [[ ${#METHOD_TOOLS_WITH_DATA[@]} -le 1 ]]; then
+        echo ""
+        echo "_Note: every competitor is a Node.js package — none ship a native binary, so this section can only show \`ferrflow\`. Cross-tool comparisons live in the **Npm** section._"
+      fi
+      ;;
+    docker)
+      if [[ ${#METHOD_TOOLS_WITH_DATA[@]} -le 1 ]]; then
+        echo ""
+        echo "_Note: no competitor publishes a first-party Docker image that is comparable to \`ghcr.io/ferrlabs/ferrflow\` (a single static binary). Wrapping the Node tools in \`node:lts\` would only re-time \`node startup + npm + the tool\` already measured in the **Npm** section, so this section is intentionally limited to \`ferrflow\`._"
+      fi
+      ;;
+  esac
+
+  unset METHOD_TOOLS_WITH_DATA
   echo ""
 done
 

--- a/tests/format-release.bats
+++ b/tests/format-release.bats
@@ -102,6 +102,61 @@ EOF
   [[ "$output" == *"### Npm"* ]]
 }
 
+@test "adds explanatory note when only ferrflow has Binary data" {
+  cat > "$TMPDIR/latest.json" <<'EOF'
+{
+  "ferrflow_version": "2.5.0",
+  "ferrflow_binary_size_mb": "5.2",
+  "ferrflow_npm_size_mb": "N/A",
+  "benchmarks": {
+    "single-ferrflow-binary-check": {"median_ms": 14.7, "stddev_ms": 0.5, "memory_mb": "12.4"}
+  }
+}
+EOF
+
+  run bash "$SCRIPT_DIR/format-release.sh" "$TMPDIR/latest.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"### Binary"* ]]
+  [[ "$output" == *"every competitor is a Node.js package"* ]]
+}
+
+@test "adds explanatory note when only ferrflow has Docker data" {
+  cat > "$TMPDIR/latest.json" <<'EOF'
+{
+  "ferrflow_version": "2.5.0",
+  "ferrflow_binary_size_mb": "5.2",
+  "ferrflow_npm_size_mb": "N/A",
+  "benchmarks": {
+    "single-ferrflow-docker-check": {"median_ms": 184.5, "stddev_ms": 3.1, "memory_mb": "46.5"}
+  }
+}
+EOF
+
+  run bash "$SCRIPT_DIR/format-release.sh" "$TMPDIR/latest.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"### Docker"* ]]
+  [[ "$output" == *"no competitor publishes a first-party Docker image"* ]]
+}
+
+@test "does not add the note when a competitor also has binary data" {
+  cat > "$TMPDIR/latest.json" <<'EOF'
+{
+  "ferrflow_version": "2.5.0",
+  "ferrflow_binary_size_mb": "5.2",
+  "ferrflow_npm_size_mb": "N/A",
+  "benchmarks": {
+    "single-ferrflow-binary-check": {"median_ms": 14.7, "stddev_ms": 0.5, "memory_mb": "12.4"},
+    "single-changesets-binary-check": {"median_ms": 50.0, "stddev_ms": 1.0, "memory_mb": "20.0"}
+  }
+}
+EOF
+
+  run bash "$SCRIPT_DIR/format-release.sh" "$TMPDIR/latest.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"### Binary"* ]]
+  [[ "$output" != *"every competitor is a Node.js package"* ]]
+}
+
 @test "renders install footprint when install_sizes present" {
   cat > "$TMPDIR/latest.json" <<'EOF'
 {


### PR DESCRIPTION
## Why this exists

The performance section in the release body renders one table per install method (Binary / Docker / Npm). Today the Binary and Docker tables only contain a row for \`ferrflow\`, which looks like competitor data was lost or filtered out. It wasn't:

- **Binary** — every documented competitor (semantic-release, changesets, standard-version, commit-and-tag-version, release-please) is a Node.js package distributed via npm. None of them publish a native binary. There is nothing to compare against.
- **Docker** — no competitor publishes a first-party image that's comparable to \`ghcr.io/ferrlabs/ferrflow\` (a single static binary). Wrapping a Node tool in a \`node:lts\` image just re-measures \`Node startup + npm install + the tool\` — i.e. the **Npm** section's number plus container overhead, which adds noise without information.

## What the PR changes

\`scripts/format-release.sh\` now appends a one-line italic footnote under the **Binary** and **Docker** sub-tables when only \`ferrflow\` has data. The note redirects readers to the **Npm** section for cross-tool comparisons. When a competitor *does* gain native-binary or comparable-Docker support in the future and lands data in either section, the note disappears automatically.

\`tests/format-release.bats\` gets three new tests covering both notes appearing, and the negative case where a competitor in the section suppresses the note.

This is a transparency fix, not a behaviour change for any existing consumer.