### PR TITLE
perf(ci): install hyperfine prebuilt instead of compiling from source

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -184,8 +184,9 @@ runs:
     # ------------------------------------------------------------------
     - name: Install hyperfine
       if: inputs.type == 'full' || inputs.type == 'all'
-      shell: bash
-      run: cargo install hyperfine
+      uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+      with:
+        tool: hyperfine
 
     - name: Install jq
       if: inputs.type == 'full' || inputs.type == 'all'


### PR DESCRIPTION
The full-benchmark path ran `cargo install hyperfine`, compiling hyperfine from source on every benchmark run (~2 min, uncached — the caller's rust-cache doesn't cover a from-source `cargo install`). Since this action is invoked on every FerrFlow main push (and PR for type=all), that cost is paid every time.

Switched to `taiki-e/install-action` (prebuilt binary, SHA-pinned per repo convention), which downloads hyperfine in seconds. No change to how benchmarks run — only how hyperfine is provisioned.