### PR TITLE
perf(bench): lower default warmup from 3 to 2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,12 @@ inputs:
   warmup:
     description: 'Number of warmup runs before timing (hyperfine --warmup)'
     required: false
-    default: '3'
+    # 2 warmups is the smallest value that still primes the OS page
+    # cache and filesystem readahead reliably (one cold + one settled
+    # iteration); going from 3 to 2 saves ~10% of the total bench
+    # wall-time across the full matrix without changing the variance
+    # of the timed runs measurably.
+    default: '2'
   runs:
     description: 'Number of timed runs (hyperfine --runs)'
     required: false

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -18,7 +18,7 @@ RAW_DIR=""
 OUTPUT_FORMAT="markdown"
 SKIP_COMPETITORS=false
 VERBOSE="${VERBOSE:-false}"
-WARMUP=3
+WARMUP=2
 RUNS=10
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
Reduces hyperfine `--warmup` from 3 to 2 in both the action input default and `run.sh`'s baseline. Across the full FerrFlow matrix (6 fixtures × ~7 tool/method pairs × ~5 commands) that's one fewer warmup iteration per measured command — roughly 10% of the bench wall-time. Variance of the timed runs is not measurably affected (one cold pass + one settled pass is enough to prime the OS page cache and FS readahead reliably).

Consumers can still override via `with.warmup: '3'` if they want the old behaviour on a noisy host.