### PR TITLE
fix(run): push tags to dummy remote so semantic-release stops failing

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -113,6 +113,12 @@ prepare_ferrflow_fixture() {
 }
 
 # Set up a dummy bare remote for tools that require one (semantic-release, etc.)
+#
+# semantic-release does `git fetch --tags origin` very early in its
+# planning phase. If the remote has no tags it exits 128 and we report
+# SKIP for the whole fixture, which is how it ended up missing from the
+# perf comparison table. Push HEAD AND tags so any fixture-defined
+# baseline tag (e.g. "v1.0.0") is visible to the tool.
 setup_dummy_remote() {
   local dir="$1"
   local bare_dir="$2"
@@ -121,6 +127,7 @@ setup_dummy_remote() {
   git -C "$bare_dir" init --bare -q 2>/dev/null
   git -C "$dir" remote add origin "$bare_dir" 2>/dev/null || true
   git -C "$dir" push -q origin HEAD 2>/dev/null || true
+  git -C "$dir" push -q origin --tags 2>/dev/null || true
 }
 
 # Measure peak RSS in MB (Linux only)


### PR DESCRIPTION
## Why semantic-release is missing from the perf comparison table

When the bench runner reaches the semantic-release step it does:

```
[semantic-release] ✘ An error occurred while running semantic-release:
ExecaError: Command failed with exit code 128: git fetch --tags /tmp/tmp.NXu6Tet4op
```

`setup_dummy_remote` does `git init --bare` + `git push origin HEAD` but **no tags**. semantic-release's planning phase fetches tags very early to resolve the previous release, sees an empty tag set, and dies with exit 128 — `run.sh` then reports `SKIP: command failed` for every (fixture, semantic-release) pair.

Same root cause is going to bite any future Node-based tool that derives version state from tags (which is most of them).

## Fix

One extra `git push --tags` after the `git push HEAD`. `-q` keeps the output silent and `|| true` matches the existing pattern — even on fixtures with no tags it's a no-op, not an error.

After this lands, semantic-release should start appearing as a real comparison row in the npm section of the perf table.