### PR TITLE
docs: describe the Fixtures-based full-benchmark flow accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Runs criterion benchmarks (`cargo bench`) and compares against a stored baseline
 
 Runs end-to-end benchmarks with [hyperfine](https://github.com/sharkdp/hyperfine) across multiple fixture sizes (single repo, mono-small, mono-medium, mono-large). Optionally compares against competitor tools (semantic-release, changesets, release-please).
 
-- Generates fixtures using `cargo run --release --bin generate-fixtures`
+- Generates fixtures via the [`FerrLabs/Fixtures`](https://github.com/FerrLabs/Fixtures) action from the JSON `definitions` directory you pass
 - Measures execution time, memory usage, and binary size
 - Compares against stored baseline and detects regressions (configurable threshold, default 25%)
 
@@ -62,4 +62,5 @@ The calling workflow must provide:
 - Rust cache (`Swatinem/rust-cache@v2`)
 - Node.js (for full benchmarks with competitors): `actions/setup-node@v6`
 - A project with `cargo bench --bench ferrflow_benchmarks` (for micro)
-- A project with `cargo run --release --bin generate-fixtures` (for full)
+- A directory of JSON fixture definitions, passed via the `definitions` input — the action generates the fixtures with [`FerrLabs/Fixtures`](https://github.com/FerrLabs/Fixtures) (for full)
+- A project that builds a release binary with `cargo build --release` — the action puts `target/release` on `PATH` and benchmarks it (for full)

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     required: false
     default: '10'
   definitions:
-    description: 'Path to TOML definitions for benchmark fixture generation'
+    description: 'Path to the directory of JSON fixture definitions for benchmark fixture generation'
     required: true
   verbose:
     description: 'Show full error output when a benchmark command fails validation'


### PR DESCRIPTION
Closes #130. Closes #131.

The action generates fixtures via the `FerrLabs/Fixtures` action from a JSON `definitions` directory, but the docs still described the old local-binary flow and mislabelled the input format:

- **#131** — `action.yml` `definitions` input said *"Path to TOML definitions"*; the generator only reads JSON (and the value is passed straight to `FerrLabs/Fixtures`, whose input is JSON). Now: *"Path to the directory of JSON fixture definitions…"*, matching Fixtures.
- **#130** — README `full` section + Requirements claimed fixtures come from `cargo run --release --bin generate-fixtures` (a binary the action never invokes). Rewritten to the real flow: fixtures come from `FerrLabs/Fixtures` (caller supplies the `definitions` dir), and the project must build a release binary (`cargo build --release`) which the action puts on PATH. Dropped the `generate-fixtures` requirement.