### PR TITLE
ci: add release concurrency guard and drop persisted creds on the bot release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
     name: Release
     needs: [lint, test]
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
@@ -45,6 +48,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # FerrFlow runs with bot: true — it pushes via an App installation
+          # token from its OIDC exchange, not the checkout-persisted
+          # GITHUB_TOKEN. Persisting GITHUB_TOKEN would let it win over the bot
+          # token on push (github-actions[bot] can't bypass branch rules).
+          persist-credentials: false
       - name: Record previous tag
         id: prev-tag
         run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #129.

Two race/auth hardening fixes on the inline `release` job in `ci.yml` (this repo has no separate release.yml — the release runs inside CI):

- **Concurrency** — added `concurrency: { group: release-${{ github.ref }}, cancel-in-progress: false }` so two main merges can't race the FerrFlow release run and trip `E2006: tag already exists`.
- **Checkout creds** — the job runs `FerrLabs/FerrFlow@v5` with `bot: true`, which pushes via an App installation token from its OIDC exchange, **not** the checkout-persisted `GITHUB_TOKEN`. Added `persist-credentials: false` so the persisted `GITHUB_TOKEN` can't win over the bot token on push (github-actions[bot] can't bypass the branch ruleset).

Note: the parent issue/#56 prescribed `checkout@v6 → v5` to dodge v6 dropping GITHUB_TOKEN on `fetch-depth: 0`. That workaround doesn't apply here because this release **doesn't use** GITHUB_TOKEN for the push (it uses the bot token) — `persist-credentials: false` on v6 is the correct, current pattern (matches the FerrLabs/.github reusable release). Kept `@v6`.