### PR TITLE
fix(bench): measure ferrflow_parallel only from the binary method

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -319,10 +319,15 @@ for tool in $TOOLS; do
 
         # Competitors are single-threaded; pin ferrflow to one thread so the
         # comparison is reproducible and apples-to-apples. par_cmd keeps the
-        # all-cores variant for the separate parallel stat.
+        # all-cores variant for the separate parallel stat — binary method
+        # only, since the parallel result file is not method-scoped and the
+        # npm (npx) and docker methods would overwrite it with node/container
+        # startup overhead instead of the binary's all-cores time.
         par_cmd=""
         if [[ "$tool" == "ferrflow" ]]; then
-          par_cmd="$full_cmd"
+          if [[ "$method" == "binary" ]]; then
+            par_cmd="$full_cmd"
+          fi
           full_cmd="$tool_cmd --jobs 1 $cmd"
         fi
 


### PR DESCRIPTION
The parallel result file (`parallel/${fixture}-${cmd}.json`) isn't scoped by install method, and ferrflow runs binary → npm → **docker**. Each method re-ran the parallel hyperfine into the same file, so docker (last) overwrote it — `ferrflow_parallel` was really measuring `docker run` container startup (~constant 165–280 ms), which made ferrflow's default mode look far slower than `--jobs 1`.

Verified on ubuntu-latest with `--timing`: `ferrflow check` is 4–6 ms in both `--jobs 1` and default — no parallel-path overhead. The stat was a harness artifact.

Fix: set `par_cmd` (the all-cores variant) only for the `binary` method, so the parallel stat is binary all-cores vs binary `--jobs 1`. The `--jobs 1` pinning still applies to every ferrflow method for the single stat.

Closes #153
