### PR TITLE
chore(deps): bump FerrLabs/Fixtures to v1.1.1 (graph mode)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Add ferrflow to PATH
         run: echo "${{ github.workspace }}/ferrflow-src/target/release" >> "$GITHUB_PATH"
       - name: Generate benchmark fixtures
-        uses: FerrLabs/Fixtures@7db03266c337749bef6f0d5c1e956b112b337b9c # v1
+        uses: FerrLabs/Fixtures@3d9971a22666f2d5d262d5a308920af191e16a4a # v1.1.1
         with:
           definitions: ferrflow-src/benchmarks/fixtures/definitions
           generated-dir: /tmp/bench-fixtures

--- a/action.yml
+++ b/action.yml
@@ -210,7 +210,7 @@ runs:
 
     - name: Generate benchmark fixtures
       if: inputs.type == 'full' || inputs.type == 'all'
-      uses: FerrLabs/Fixtures@7c4919f7db721c94fe8a91558a86759f4b63b004 # v1.0.5
+      uses: FerrLabs/Fixtures@3d9971a22666f2d5d262d5a308920af191e16a4a # v1.1.1
       with:
         definitions: ${{ inputs.definitions }}
         generated-dir: /tmp/bench-fixtures


### PR DESCRIPTION
Closes #158. Unblocks FerrLabs/FerrFlow#630.

Bumps the pinned `FerrLabs/Fixtures` (in `action.yml` and `ci.yml`) from v1.0.5 → **v1.1.1**, which carries the `generate.graph` dependency-DAG mode (FerrLabs/Fixtures#137 + #139). Without this, the generator ignores `graph: true` in the new `complex.json` benchmark definition and produces a flat fixture with no cascade.

Interim unblock while the floating-tag release issue (FerrLabs/FerrFlow#662, which stranded `Fixtures@v1` at v1.0.5) is resolved — a follow-up FerrFlow PR re-pins the Benchmarks action to this version.