### PR TITLE
feat(action): add binary-dir input to reuse a prebuilt ferrflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Reusable GitHub Action for running FerrFlow benchmarks and detecting performance
 | `full-regression-threshold` | Relative threshold for full benchmark regressions (e.g. `125%`) | `125%` |
 | `binary-size-threshold` | Binary size growth threshold (e.g. `120%`) | `120%` |
 | `comment-on-pr` | Post benchmark results as PR comment | `true` |
-| `warmup` | Number of warmup runs before timing (hyperfine `--warmup`) | `3` |
+| `warmup` | Number of warmup runs before timing (hyperfine `--warmup`) | `2` |
 | `runs` | Number of timed runs (hyperfine `--runs`) | `10` |
 | `definitions` | Path to fixture definitions for benchmark generation | required |
 | `verbose` | Show full error output when a benchmark command fails validation | `false` |
 | `ferrflow-token` | GitHub token for PR comments and artifact access | required |
+| `group-filter` | Criterion bench group filter (substring) for micro matrix sharding | `''` |
+| `binary-dir` | Directory holding a prebuilt `ferrflow` executable. When set, the full benchmark skips its own `cargo build --release` and puts this directory on PATH | `''` |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,10 @@ inputs:
     description: 'Optional criterion bench group filter (substring). If set, only benches matching this are run. Use for matrix sharding.'
     required: false
     default: ''
+  binary-dir:
+    description: 'Directory holding a prebuilt `ferrflow` executable. When set, the full benchmark skips its own `cargo build --release` and puts this directory on PATH instead. Point it at a downloaded build artifact to avoid recompiling a binary the caller already produced.'
+    required: false
+    default: ''
 
 outputs:
   regression-detected:
@@ -199,14 +203,27 @@ runs:
       run: sudo apt-get install -y jq
 
     - name: Build project
-      if: inputs.type == 'full' || inputs.type == 'all'
+      if: (inputs.type == 'full' || inputs.type == 'all') && inputs.binary-dir == ''
       shell: bash
       run: cargo build --release
 
     - name: Add binary to PATH
       if: inputs.type == 'full' || inputs.type == 'all'
       shell: bash
-      run: echo "$PWD/target/release" >> $GITHUB_PATH
+      env:
+        BINARY_DIR: ${{ inputs.binary-dir }}
+      run: |
+        if [[ -n "$BINARY_DIR" ]]; then
+          dir=$(cd "$BINARY_DIR" && pwd)
+          if [[ ! -x "$dir/ferrflow" ]]; then
+            echo "::error::binary-dir '$BINARY_DIR' has no executable 'ferrflow'"
+            ls -la "$dir" || true
+            exit 1
+          fi
+        else
+          dir="$PWD/target/release"
+        fi
+        echo "$dir" >> "$GITHUB_PATH"
 
     - name: Generate benchmark fixtures
       if: inputs.type == 'full' || inputs.type == 'all'

--- a/action.yml
+++ b/action.yml
@@ -202,6 +202,25 @@ runs:
       shell: bash
       run: sudo apt-get install -y jq
 
+    # Stage the caller's binary where a local build would have produced it, so
+    # the PATH entry below stays a constant. Feeding an input into GITHUB_PATH
+    # would let a caller inject an arbitrary PATH entry into this action.
+    - name: Stage prebuilt binary
+      if: (inputs.type == 'full' || inputs.type == 'all') && inputs.binary-dir != ''
+      shell: bash
+      env:
+        BINARY_DIR: ${{ inputs.binary-dir }}
+      run: |
+        if [[ ! -f "$BINARY_DIR/ferrflow" ]]; then
+          echo "::error::binary-dir '$BINARY_DIR' has no 'ferrflow' binary"
+          ls -la "$BINARY_DIR" || true
+          exit 1
+        fi
+        mkdir -p target/release
+        cp "$BINARY_DIR/ferrflow" target/release/ferrflow
+        # Artifact downloads drop the executable bit.
+        chmod +x target/release/ferrflow
+
     - name: Build project
       if: (inputs.type == 'full' || inputs.type == 'all') && inputs.binary-dir == ''
       shell: bash
@@ -210,20 +229,7 @@ runs:
     - name: Add binary to PATH
       if: inputs.type == 'full' || inputs.type == 'all'
       shell: bash
-      env:
-        BINARY_DIR: ${{ inputs.binary-dir }}
-      run: |
-        if [[ -n "$BINARY_DIR" ]]; then
-          dir=$(cd "$BINARY_DIR" && pwd)
-          if [[ ! -x "$dir/ferrflow" ]]; then
-            echo "::error::binary-dir '$BINARY_DIR' has no executable 'ferrflow'"
-            ls -la "$dir" || true
-            exit 1
-          fi
-        else
-          dir="$PWD/target/release"
-        fi
-        echo "$dir" >> "$GITHUB_PATH"
+      run: echo "$PWD/target/release" >> $GITHUB_PATH
 
     - name: Generate benchmark fixtures
       if: inputs.type == 'full' || inputs.type == 'all'


### PR DESCRIPTION
Closes #160.

The `full` benchmark ran its own `cargo build --release`, even though callers (FerrFlow) already build the release binary in an earlier job and upload it as an artifact — so every run paid a full release compile twice.

- New **`binary-dir`** input. When set, the build step is skipped and that directory goes on PATH instead; it fails loudly if the directory holds no executable `ferrflow` rather than silently benchmarking whatever is on PATH.
- Default `''` keeps the current behaviour (build in-place), so existing callers are unaffected.

Also refreshed two stale rows in the README input table while touching it: `warmup`'s documented default was `3` (the action defaults to `2`) and `group-filter` was missing entirely.

A companion FerrFlow PR wires its benchmark job to the `ferrflow-binary` artifact it already publishes.