### PR TITLE
fix(bench): measure ferrflow cold, report the cache separately

### DIFF
--- a/scripts/merge-results.sh
+++ b/scripts/merge-results.sh
@@ -6,10 +6,11 @@ set -euo pipefail
 # Usage: ./merge-results.sh <partials-dir> <output.json>
 #
 # Each shard benchmarks a distinct fixture, so the `benchmarks`,
-# `ferrflow_parallel` and `install_sizes` maps are keyed by fixture and never
-# collide — merging them is a plain union. Run-level metadata (version, binary
-# sizes, runner_cores) is taken from the first partial: every shard benchmarks
-# the same binary, and shards run on identically-specced runners.
+# `ferrflow_parallel`, `ferrflow_cached` and `install_sizes` maps are keyed by
+# fixture and never collide — merging them is a plain union. Run-level metadata
+# (version, binary sizes, runner_cores, warmup, runs) is taken from the first
+# partial: every shard benchmarks the same binary with the same settings, and
+# shards run on identically-specced runners.
 #
 # Requires: jq
 
@@ -43,6 +44,7 @@ jq -s '
   + {
       benchmarks: (map(.benchmarks // {}) | add),
       ferrflow_parallel: (map(.ferrflow_parallel // {}) | add),
+      ferrflow_cached: (map(.ferrflow_cached // {}) | add),
       install_sizes: (map(.install_sizes // {}) | add)
     }
 ' "${files[@]}" > "$OUTPUT"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -331,6 +331,24 @@ for tool in $TOOLS; do
           full_cmd="$tool_cmd --jobs 1 $cmd"
         fi
 
+        # `ferrflow check` memoises its result under .git/ferrflow-cache (5 min
+        # TTL, keyed by HEAD+tags+config). The fixture never changes between
+        # runs, so without intervention hyperfine's warmup primes the cache and
+        # every timed run is a hit — the headline then reads a near-constant few
+        # ms whatever the history size, which is the cache, not the work. No
+        # competitor has an equivalent, so the comparable number is the cold
+        # one: drop the cache before each timed run. The warm number is worth
+        # publishing too, but as its own stat (see cache_cmd below), never as
+        # the head-to-head — same rule as --jobs 1 for the parallel stat.
+        prepare_args=()
+        cache_cmd=""
+        if [[ "$tool" == "ferrflow" ]]; then
+          prepare_args=(--prepare "rm -rf $tmp_dir/.git/ferrflow-cache")
+          if [[ "$method" == "binary" && "$cmd_name" == "check" ]]; then
+            cache_cmd="$full_cmd"
+          fi
+        fi
+
         label="${tool}/${method}"
         raw_file="$RAW_DIR/${fixture}-${tool}-${method}-${cmd_name}.json"
 
@@ -355,6 +373,7 @@ for tool in $TOOLS; do
         hyperfine \
           --warmup "$WARMUP" \
           --runs "$RUNS" \
+          "${prepare_args[@]}" \
           --export-json "$raw_file" \
           --shell=bash \
           "cd $tmp_dir && $full_cmd >/dev/null 2>&1" \
@@ -370,9 +389,23 @@ for tool in $TOOLS; do
           hyperfine \
             --warmup "$WARMUP" \
             --runs "$RUNS" \
+            --prepare "rm -rf $tmp_dir/.git/ferrflow-cache" \
             --export-json "$RAW_DIR/parallel/${fixture}-${cmd_name}.json" \
             --shell=bash \
             "cd $tmp_dir && $par_cmd >/dev/null 2>&1" \
+            2>/dev/null
+        fi
+
+        # Warm-cache stat: no --prepare, so the warmup primes the cache and the
+        # timed runs measure a hit. Deliberately kept out of `benchmarks`.
+        if [[ -n "$cache_cmd" ]]; then
+          mkdir -p "$RAW_DIR/cached"
+          hyperfine \
+            --warmup "$WARMUP" \
+            --runs "$RUNS" \
+            --export-json "$RAW_DIR/cached/${fixture}-${cmd_name}.json" \
+            --shell=bash \
+            "cd $tmp_dir && $cache_cmd >/dev/null 2>&1" \
             2>/dev/null
         fi
       done
@@ -430,6 +463,19 @@ for raw_file in "$RAW_DIR"/parallel/*.json; do
     '.[$k] = {median_ms: $median, stddev_ms: $stddev}')
 done
 
+FERRFLOW_CACHED_OBJ='{}'
+for raw_file in "$RAW_DIR"/cached/*.json; do
+  [[ -f "$raw_file" ]] || continue
+  bname=$(basename "$raw_file" .json)
+  median=$(extract_median "$raw_file" 2>/dev/null || echo "0")
+  stddev=$(extract_stddev "$raw_file" 2>/dev/null || echo "0")
+  FERRFLOW_CACHED_OBJ=$(echo "$FERRFLOW_CACHED_OBJ" | jq \
+    --arg k "$bname" \
+    --argjson median "$median" \
+    --argjson stddev "$stddev" \
+    '.[$k] = {median_ms: $median, stddev_ms: $stddev}')
+done
+
 INSTALL_SIZES_OBJ='{}'
 for size_file in "$RAW_DIR"/*-size.txt; do
   [[ -f "$size_file" ]] || continue
@@ -452,8 +498,11 @@ jq -n \
   --arg bin "$FERRFLOW_BIN_SIZE" \
   --arg npm "$FERRFLOW_NPM_SIZE" \
   --argjson cores "$RUNNER_CORES" \
+  --argjson warmup "$WARMUP" \
+  --argjson runs "$RUNS" \
   --argjson benchmarks "$BENCHMARKS_OBJ" \
   --argjson ferrflow_parallel "$FERRFLOW_PARALLEL_OBJ" \
+  --argjson ferrflow_cached "$FERRFLOW_CACHED_OBJ" \
   --argjson install_sizes "$INSTALL_SIZES_OBJ" \
   '{
     timestamp: $ts,
@@ -461,8 +510,11 @@ jq -n \
     ferrflow_binary_size_mb: $bin,
     ferrflow_npm_size_mb: $npm,
     runner_cores: $cores,
+    warmup: $warmup,
+    runs: $runs,
     benchmarks: $benchmarks,
     ferrflow_parallel: $ferrflow_parallel,
+    ferrflow_cached: $ferrflow_cached,
     install_sizes: $install_sizes
   }' > "$RESULTS_DIR/latest.json"
 

--- a/tests/merge-results.bats
+++ b/tests/merge-results.bats
@@ -19,6 +19,8 @@ make_partial() {
   "ferrflow_version": "ferrflow 5.29.0",
   "ferrflow_binary_size_mb": "9.0",
   "runner_cores": 4,
+  "warmup": 2,
+  "runs": 30,
   "benchmarks": {$benchmarks},
   "ferrflow_parallel": {$parallel},
   "install_sizes": {$sizes}
@@ -51,6 +53,9 @@ EOF
   [ "$(jq -r '.ferrflow_version' "$TMPDIR/latest.json")" = "ferrflow 5.29.0" ]
   [ "$(jq -r '.ferrflow_binary_size_mb' "$TMPDIR/latest.json")" = "9.0" ]
   [ "$(jq -r '.runner_cores' "$TMPDIR/latest.json")" = "4" ]
+  # The site renders these, so they have to survive the merge.
+  [ "$(jq -r '.warmup' "$TMPDIR/latest.json")" = "2" ]
+  [ "$(jq -r '.runs' "$TMPDIR/latest.json")" = "30" ]
 }
 
 @test "merges ferrflow_parallel and install_sizes too" {
@@ -64,6 +69,25 @@ EOF
 
   [ "$(jq '.ferrflow_parallel | length' "$TMPDIR/latest.json")" -eq 2 ]
   [ "$(jq '.install_sizes | length' "$TMPDIR/latest.json")" -eq 2 ]
+}
+
+@test "merges the warm-cache stat across shards" {
+  cat > "$TMPDIR/partials/a.json" <<'EOF'
+{"benchmarks":{"a-ferrflow-binary-check":{"median_ms":21.0}},
+ "ferrflow_cached":{"a-check":{"median_ms":3.0}}}
+EOF
+  cat > "$TMPDIR/partials/b.json" <<'EOF'
+{"benchmarks":{"b-ferrflow-binary-check":{"median_ms":740.0}},
+ "ferrflow_cached":{"b-check":{"median_ms":5.0}}}
+EOF
+
+  run "$SCRIPT_DIR/merge-results.sh" "$TMPDIR/partials" "$TMPDIR/latest.json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq '.ferrflow_cached | length' "$TMPDIR/latest.json")" -eq 2 ]
+  [ "$(jq '.ferrflow_cached["b-check"].median_ms == 5' "$TMPDIR/latest.json")" = "true" ]
+  # The cold number stays the headline; the warm one must not leak into it.
+  [ "$(jq '.benchmarks["b-ferrflow-binary-check"].median_ms == 740' "$TMPDIR/latest.json")" = "true" ]
 }
 
 @test "a single shard round-trips unchanged" {


### PR DESCRIPTION
Closes #169. Also emits `warmup`/`runs` so the site stops hardcoding them.

**The headline was measuring a cache hit.** `ferrflow check` memoises under `.git/ferrflow-cache` (5 min TTL, keyed by HEAD+tags+config) and returns early on a hit. hyperfine got no `--prepare`, the fixture never changes, so the warmup primed the cache and every timed run read it back. On the published page ferrflow's `check` sits flat at ~3-5 ms from `1 x 100` to `200 packages x 10k commits` — work doesn't stay flat across a 100x bigger history; a cache lookup does. The uncached `release --dry-run` stat scales properly on the same fixtures (23 ms -> 732 ms). No competitor has such a cache, so the chart compared our cache against their work.

- **`--prepare` drops the cache before every timed ferrflow run**, so `benchmarks` (the head-to-head) is now cold and comparable. Applied to the parallel stat too.
- **New `ferrflow_cached` map** — the warm number, measured deliberately (no `--prepare`, warmup primes it), kept out of `benchmarks`. The cache is a real feature and worth showing; it just isn't a head-to-head result. Same rule the repo already applies with `--jobs 1` vs `ferrflow_parallel`.
- **`warmup` and `runs` are now emitted in `latest.json`.** The site hardcodes "3 warmup runs and 10 timed runs" — both already wrong (the action defaults to 2, and FerrFlow now passes 30). Publishing them lets the site read the truth instead of drifting.

`merge-results.sh` unions `ferrflow_cached` like the other fixture-keyed maps; covered by a new bats test asserting the warm number doesn't leak into the headline. Verified locally: `bash -n` on both scripts, the empty-array `prepare_args` expansion under `set -u`, and a real merge carrying `warmup`/`runs`/`ferrflow_cached`.

**Expect the published ferrflow numbers to jump** on the next run — that's the point. They'll be defensible, and FerrFlow still wins; it just wins by a real margin instead of an unfair one.