### PR TITLE
feat(ci): dispatch Renovate when the rebase box is ticked

### DIFF
--- a/.github/workflows/renovate-rebase.yml
+++ b/.github/workflows/renovate-rebase.yml
@@ -1,0 +1,12 @@
+name: Renovate rebase now
+
+on:
+  pull_request:
+    types: [edited]
+
+jobs:
+  dispatch:
+    uses: FerrLabs/.github/.github/workflows/reusable-renovate-dispatch.yml@a4b4a70d116127cd49f09ad6f363ac55fd8f6501 # main
+    with:
+      runner: ubuntu-latest
+    secrets: inherit


### PR DESCRIPTION
Ticking Renovate's rebase/retry checkbox only edits the PR body, and self-hosted Renovate does not read it until its next run — so with the `*/30` cron you wait up to 30 minutes for something that looks like a button.

This wires the body edit to `reusable-renovate-dispatch.yml`, which triggers a Renovate run scoped to this repo via the `repoFilter` input, so the rebase starts in seconds.

It cannot loop: Renovate unticks the box after rebasing, and that edit no longer matches the guard.

Passes `runner: ubuntu-latest` because this repo is public and the `ferrlabs-k8s` group sets `allows_public_repositories=false`.

Part of FerrLabs/.github#159