### PR TITLE
fix(bench): point the dummy remote's HEAD at the branch we push

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -116,19 +116,36 @@ prepare_ferrflow_fixture() {
 # Set up a dummy bare remote for tools that require one (semantic-release, etc.)
 #
 # semantic-release does `git fetch --tags origin` very early in its
-# planning phase. If the remote has no tags it exits 128 and we report
-# SKIP for the whole fixture, which is how it ended up missing from the
-# perf comparison table. Push HEAD AND tags so any fixture-defined
-# baseline tag (e.g. "v1.0.0") is visible to the tool.
+# planning phase, and that fetch resolves the remote's HEAD. `git init
+# --bare` points HEAD at refs/heads/<init.defaultBranch> — `master` on a
+# stock runner — while the fixtures are on `main`, so HEAD dangles and the
+# fetch dies with `fatal: couldn't find remote ref HEAD` (exit 128). The
+# tool then SKIPs every fixture and vanishes from the comparison entirely.
+#
+# Point HEAD at the branch we actually pushed. Don't pass `-b` to init:
+# that reads as a fix while still leaving HEAD wrong wherever the fixture
+# isn't on that branch.
+#
+# Failures here are fatal on purpose. Silencing them is what let this sit
+# unnoticed: every step "succeeded", and the tool just quietly disappeared.
 setup_dummy_remote() {
   local dir="$1"
   local bare_dir="$2"
 
   [[ -d "$dir/.git" ]] || return 0
-  git -C "$bare_dir" init --bare -q 2>/dev/null
-  git -C "$dir" remote add origin "$bare_dir" 2>/dev/null || true
-  git -C "$dir" push -q origin HEAD 2>/dev/null || true
-  git -C "$dir" push -q origin --tags 2>/dev/null || true
+
+  local branch
+  branch=$(git -C "$dir" symbolic-ref --quiet --short HEAD) || {
+    echo "  setup_dummy_remote: fixture $dir has a detached HEAD" >&2
+    return 1
+  }
+
+  git -C "$bare_dir" init --bare -q
+  git -C "$dir" remote add origin "$bare_dir" 2>/dev/null || \
+    git -C "$dir" remote set-url origin "$bare_dir"
+  git -C "$dir" push -q origin "HEAD:refs/heads/$branch"
+  git -C "$dir" push -q origin --tags
+  git -C "$bare_dir" symbolic-ref HEAD "refs/heads/$branch"
 }
 
 # Measure peak RSS in MB (Linux only)


### PR DESCRIPTION
Closes #177.

`semantic-release` contributes **zero cells** to the benchmark and is missing from the perf page entirely. It fails at `git fetch --tags origin`, which it runs early in planning:

```
fatal: couldn't find remote ref HEAD   (exit 128)
```

`git init --bare` points `HEAD` at `refs/heads/<init.defaultBranch>` — `master` on a stock runner — while the fixtures are on `main`. The bare repo ends up with `refs/heads/main` and a `HEAD` symref to a branch that does not exist. semantic-release's fetch resolves `HEAD`, gets nothing, and exits 128. `run.sh` reports `SKIP: command failed` and the tool disappears.

The existing comment blames missing tags and an earlier fix pushed tags to address it. That diagnosis was wrong: the tags were already there.

```
$ git -C bare symbolic-ref HEAD          -> refs/heads/master
$ git -C bare for-each-ref               -> refs/heads/main, refs/tags/v0.1.0
$ git -C fx fetch --tags bare            -> fatal: couldn't find remote ref HEAD
```

**The fix** points `HEAD` at the branch we actually push. Not `init -b`: that reads as a fix while still leaving `HEAD` wrong for any fixture not on that branch.

**`setup_dummy_remote` no longer swallows errors.** Every git call was `2>/dev/null || true`, so the function reported success while producing a broken remote — that is precisely why a fully broken competitor passed for a working one. Failures are fatal now, and a detached-HEAD fixture says so.

Verified against the real thing under CI conditions (`init.defaultBranch=master`, `single` fixture with its real `tool_configs`):

```
$ npx --yes semantic-release@23 --dry-run --no-ci
...
[semantic-release] › ℹ Release note for version 1.1.0:
exit=0
```

It runs, analyses the commits and generates notes. **Expect semantic-release to appear in the chart on the next run** — around 3.7 s on the `single` fixture locally (~1.6 s of it work, the rest startup), so it lands as the heaviest competitor by a wide margin.

Worth noting the local-vs-CI trap: this only reproduces where `init.defaultBranch` is unset or `master`. My machine has it set to `main`, so my first local repro passed and told me the setup was fine. That is the same gap that let this sit unnoticed in CI.
