### PR TITLE
fix(bench): address the dummy remote as a file:// URL

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -126,6 +126,14 @@ prepare_ferrflow_fixture() {
 # that reads as a fix while still leaving HEAD wrong wherever the fixture
 # isn't on that branch.
 #
+# The remote is addressed as a `file://` URL, not a bare path, because
+# semantic-release derives `repositoryUrl` from origin and feeds it to
+# `new URL()` when generating notes. `/tmp/tmp.abc` throws `TypeError:
+# Invalid URL` and the fixture SKIPs; `file:///tmp/tmp.abc` parses, and git
+# clones/fetches from it just the same. (A bare Windows path happens to
+# parse — `C:/x` reads as protocol `c:` — so this reproduces only on Linux,
+# which is exactly how it survived a local check.)
+#
 # Failures here are fatal on purpose. Silencing them is what let this sit
 # unnoticed: every step "succeeded", and the tool just quietly disappeared.
 setup_dummy_remote() {
@@ -140,9 +148,15 @@ setup_dummy_remote() {
     return 1
   }
 
+  local url
+  case "$bare_dir" in
+    /*) url="file://$bare_dir" ;;
+    *) url="file:///$bare_dir" ;;
+  esac
+
   git -C "$bare_dir" init --bare -q
-  git -C "$dir" remote add origin "$bare_dir" 2>/dev/null || \
-    git -C "$dir" remote set-url origin "$bare_dir"
+  git -C "$dir" remote add origin "$url" 2>/dev/null || \
+    git -C "$dir" remote set-url origin "$url"
   git -C "$dir" push -q origin "HEAD:refs/heads/$branch"
   git -C "$dir" push -q origin --tags
   git -C "$bare_dir" symbolic-ref HEAD "refs/heads/$branch"

--- a/tests/setup-dummy-remote.bats
+++ b/tests/setup-dummy-remote.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+# setup_dummy_remote lives in run.sh, which needs hyperfine and a full fixture
+# tree to execute. Source just the function.
+RUN_SH="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/run.sh"
+
+setup() {
+  TMPDIR="$(mktemp -d)"
+  FX="$TMPDIR/fx"
+  BARE="$TMPDIR/bare"
+  mkdir -p "$FX" "$BARE"
+  # `master` is the stock runner default and what makes the HEAD bug appear;
+  # a machine with init.defaultBranch=main hides it.
+  git -C "$FX" -c init.defaultBranch=main init -q
+  git -C "$FX" config user.email t@t.t
+  git -C "$FX" config user.name t
+  echo hi > "$FX/f.txt"
+  git -C "$FX" add -A
+  git -C "$FX" commit -qm "chore: initial commit"
+  git -C "$FX" tag v0.1.0
+  git -C "$BARE" -c init.defaultBranch=master init --bare -q
+
+  eval "$(sed -n '/^setup_dummy_remote() {/,/^}/p' "$RUN_SH")"
+}
+
+teardown() { rm -rf "$TMPDIR"; }
+
+origin_url() { git -C "$FX" remote get-url origin; }
+
+# semantic-release feeds origin to `new URL()`; a bare path throws
+# `TypeError: Invalid URL` and the tool SKIPs the fixture entirely.
+@test "origin is a file:// URL, not a bare path" {
+  run setup_dummy_remote "$FX" "$BARE"
+  [ "$status" -eq 0 ]
+  [[ "$(origin_url)" == file://* ]]
+}
+
+# Ties the assertion to the actual consumer. Note this one only bites on
+# POSIX: a Windows path parses (`C:/x` reads as protocol `c:`), so it goes
+# green on a dev box even with a bare path. The test above is the portable
+# guard; this one is why.
+@test "the origin URL is parseable by new URL()" {
+  setup_dummy_remote "$FX" "$BARE"
+  run node -e "new URL(process.argv[1]); console.log('ok')" "$(origin_url)"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ok" ]
+}
+
+# `git init --bare` points HEAD at init.defaultBranch (master on a stock
+# runner) while fixtures are on main, so `git fetch` dies on a dangling HEAD.
+@test "the remote's HEAD points at the branch we pushed" {
+  setup_dummy_remote "$FX" "$BARE"
+  [ "$(git -C "$BARE" symbolic-ref HEAD)" = "refs/heads/main" ]
+}
+
+@test "git can fetch from the remote we built" {
+  setup_dummy_remote "$FX" "$BARE"
+  run git -C "$FX" fetch --tags "$(origin_url)"
+  [ "$status" -eq 0 ]
+}
+
+@test "commits and tags actually land on the remote" {
+  setup_dummy_remote "$FX" "$BARE"
+  run git -C "$BARE" for-each-ref --format='%(refname)'
+  [[ "$output" == *"refs/heads/main"* ]]
+  [[ "$output" == *"refs/tags/v0.1.0"* ]]
+}
+
+@test "a detached HEAD fails loudly instead of building a broken remote" {
+  git -C "$FX" checkout -q --detach HEAD
+  run setup_dummy_remote "$FX" "$BARE"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"detached HEAD"* ]]
+}
+
+@test "re-running against an existing origin is not fatal" {
+  setup_dummy_remote "$FX" "$BARE"
+  run setup_dummy_remote "$FX" "$BARE"
+  [ "$status" -eq 0 ]
+  [[ "$(origin_url)" == file://* ]]
+}


### PR DESCRIPTION
Follow-up to #178, which fixed a real bug but not the one that mattered. `semantic-release` still contributes **zero cells**: I checked the artifact from the run after #178 shipped rather than trusting the green tick, and it is still absent.

#178 fixed the dangling remote `HEAD` (`fatal: couldn't find remote ref HEAD`). That was real — semantic-release now gets past its `git fetch` and hyperfine measures it on the `floor` fixture (1.352 s ± 0.024 s, 30 runs). But `floor` cells are stripped from `benchmarks` by design, and the one fixture that matters still SKIPs:

```
[semantic-release] › ℹ  Found git tag v0.1.0 associated with version 0.1.0 on branch main
[semantic-release] › ℹ  Found 100 commits since last release
[semantic-release] › ✘  Failed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[semantic-release] › ✘  An error occurred while running semantic-release: TypeError: Invalid URL
```

It analyses the commits fine, then dies generating notes. semantic-release derives `repositoryUrl` from `origin` and hands it to `new URL()`. Our origin is the bare path `mktemp -d` returned:

```
$ node -e "new URL('/tmp/tmp.abc123')"        -> TypeError: Invalid URL
$ node -e "new URL('file:///tmp/tmp.abc123')" -> ok, protocol file:
$ node -e "new URL('C:/Users/bryan/x')"       -> ok, protocol c:
```

That last line is why #178 looked right. **My local verification passed because a Windows path parses as a URL** — `C:` reads as a scheme. The release notes it produced were full of `https://C/Users/bryan/...` links and I did not stop to ask why. On Linux the same code throws. `floor` masks it further: one commit, nothing releasable, so semantic-release exits before `generateNotes` ever runs.

Addressing the remote as `file://` fixes it — a valid URL, and git clones and fetches from it identically. Verified end to end: `generateNotes` now **completes**, and semantic-release resolves "the next release version is 0.2.0".

**Tests**, because this bug has now outlived two fixes. `setup_dummy_remote` is sourced out of `run.sh` and pinned on: origin is a `file://` URL, `new URL()` accepts it, the remote's `HEAD` matches the pushed branch, `git fetch` works, refs and tags land, a detached HEAD fails loudly, and a re-run is not fatal. The bare-path regression is verified to make test 1 fail.

One caveat worth stating: the `new URL()` test only bites on POSIX — on Windows it goes green even with the bare path, the same trap as above. The `file://` prefix assertion is the portable guard; that test is documentation of why. It is commented as such.
