### PR TITLE
fix(bench): disable telemetry so runs measure work, not network waits

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -46,6 +46,15 @@ fi
 
 RAW_DIR="$RESULTS_DIR/raw"
 
+# The benchmark measures the tools' work, not the network. ferrflow's
+# telemetry blocks process exit on HTTPS POSTs when enabled (one event per
+# bumped package), which added ~550 ms of pure wait to every timed run on the
+# `complex` fixture — 87% of the published number — while fixtures whose
+# config omits the `workspace` object dodged it entirely through a default
+# quirk. DO_NOT_TRACK also covers competitors that honour the convention.
+export FERRFLOW_TELEMETRY=0
+export DO_NOT_TRACK=1
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Investigation of why `complex` still trails after the packed fixtures (FerrLabs/Fixtures#144): the "recoverMissedReleases work" is not work.

The CI hyperfine line for `complex` ferrflow gave it away: **wall 659 ms, User+System = 151 ms** — the process spends ~500 ms *waiting*, not computing. And the warm-cache run on the same shard: 312 ms wall for 7 ms of CPU. A/B on the exact CI fixture, same binary, same machine:

```
telemetry OFF : 81 ms
telemetry ON  : 1474 ms   (×18)
```

ferrflow's telemetry sends one `VersionBump` event per bumped package plus a `Check` event — 51 HTTPS POSTs on `complex` — and `telemetry::flush()` joins those threads before exit (5 s deadline). The CLI's exit blocks on the network.

Why only `complex` was hit: a default-divergence quirk in ferrflow's config. `workspace` present (complex has `recoverMissedReleases`) → serde field default → telemetry **on**; `workspace` object absent entirely (mono-large's auto-generated config, floor, single) → `#[derive(Default)]` → telemetry **off**. So exactly one fixture paid ~550 ms of network wait per run — 87% of its published 635 ms — and the honest `recoverMissedReleases` cost is ~15 ms. Both ferrflow-side issues are filed separately; this PR fixes the measurement.

`FERRFLOW_TELEMETRY=0` plus `DO_NOT_TRACK=1` at the top of the runner: we benchmark the tools' work, not the latency to our own API. `DO_NOT_TRACK` also covers any competitor honouring the convention, which is only fair.

Expect `complex` ferrflow to drop from ~635 ms to ~80-150 ms on the next run — which should finally flip the one cell where ferrflow trails.
