### PR TITLE
fix(bench): bucket competitors under release-dry-run for a like-for-like head-to-head

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -348,10 +348,15 @@ for tool in $TOOLS; do
       readarray -t cmds < <(jq -r --arg t "$tool" '.[$t].commands[]' "$TOOLS_JSON")
 
       for cmd in "${cmds[@]}"; do
-        # For tools with empty command (semantic-release, changesets), the full command is in tool_cmd
+        # Empty command means the tool's single dry-run planning invocation lives
+        # entirely in tool_cmd (semantic-release --dry-run, standard-version
+        # --dry-run, commit-and-tag-version --dry-run, changesets status). Bucket
+        # it under the same name as ferrflow's `release --dry-run` so the head-to-head
+        # compares the same operation (compute next version + notes, write nothing)
+        # for every tool, not ferrflow's lighter `check` against their full dry-run.
         if [[ -z "$cmd" ]]; then
           full_cmd="$tool_cmd"
-          cmd_name="check"
+          cmd_name="release-dry-run"
         else
           full_cmd="$tool_cmd $cmd"
           cmd_name=$(echo "$cmd" | tr ' ' '-' | tr -d '-')


### PR DESCRIPTION
Closes #187

The competitive head-to-head compared **different operations**: competitors ran their dry-run release planning while their result was filed under the `check` bucket, so the site showed `ferrflow check` (a lighter read-only planning check) against the competitors' full `--dry-run`.

This changes the empty-command fallback so a competitor's single dry-run invocation is bucketed as `release-dry-run` — the same key as `ferrflow release --dry-run`. The site's `buildGrid` is data-driven (it shows whichever command the competitors carry), so the displayed comparison automatically becomes `release --dry-run` for every tool: compute next version + notes, write nothing.

ferrflow still benchmarks `check` (used only by the separately-labelled warm-cache stat), and its `release --dry-run` cell already existed — it just never had competitors in the same column until now.

No behaviour change to the compare/derive scripts; bats fixtures use arbitrary keys and are unaffected. Effective once FerrFlow bumps its pinned `FerrLabs/Benchmarks` ref and the next bench run refreshes the site data.