### PR TITLE
ci: bump renovate-rebase dispatch pin to the fixed reusable

### DIFF
--- a/.github/workflows/renovate-rebase.yml
+++ b/.github/workflows/renovate-rebase.yml
@@ -1,12 +1,4 @@
 name: Renovate rebase now
 
 on:
-  pull_request:
-    types: [edited]
-
-jobs:
-  dispatch:
-    uses: FerrLabs/.github/.github/workflows/reusable-renovate-dispatch.yml@2294da4af236f9adc02beaa3829afb499be0857a # main
-    with:
-      runner: ubuntu-latest
-    secrets: inherit
+  pull_request


### PR DESCRIPTION
Bumps the `reusable-renovate-dispatch.yml` pin to `2c9830792d651c9c46732adc848af5101bed7ec8` so instant-rebase dispatches via the Renovate GitHub App. Refs FerrLabs/.github#174.