### PR TITLE
chore(funding): sponsor the FerrLabs org instead of a personal account

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: BryanFRD
+github: FerrLabs


### PR DESCRIPTION
Closes #234

```diff
-github: BryanFRD
+github: FerrLabs
```

The org-wide default in `FerrLabs/.github` was pointed at the org in FerrLabs/.github#291, but a repo-level `FUNDING.yml` overrides it, so this repo kept funding a personal account.

The `github:` key takes an account name rather than a URL, so this resolves to `github.com/sponsors/FerrLabs`. The org has a public Sponsors listing.