### PR TITLE
chore(funding): add the FerrLabs Open Collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: FerrLabs
+open_collective: ferrlabs


### PR DESCRIPTION
Closes #236

```diff
 github: FerrLabs
+open_collective: ferrlabs
```

FerrLabs has a public collective at https://opencollective.com/ferrlabs that accepts contributions. GitHub renders both entries in the Sponsor dropdown, so this adds a route for anyone who needs an invoice or a fiscal host rather than GitHub Sponsors.

This repo ships its own `FUNDING.yml`, which overrides the org-wide default in `FerrLabs/.github`, so it needs the entry too.

The `open_collective` key takes the collective **slug**. The `/dashboard/ferrlabs` URL is the admin view and would have sent contributors to a page they cannot use, so it is deliberately not what is written here.